### PR TITLE
test-only endpoint for clearing mongo collection

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -16,6 +16,7 @@
 
 import com.google.inject.name.Names
 import com.google.inject.{AbstractModule, Provides}
+import repositories.test.{TestOnlyMongoRepository, TestOnlyRepository}
 import repositories.{MongoDBProvider, RegistrationMongoRepository, RegistrationRepository}
 
 class Module extends AbstractModule {
@@ -24,6 +25,7 @@ class Module extends AbstractModule {
 
   override def configure(): Unit = {
     bind(classOf[RegistrationRepository]).to(classOf[RegistrationMongoRepository])
+    bind(classOf[TestOnlyRepository]).to(classOf[TestOnlyMongoRepository])
     bind(classOf[connectors.AuthConnector]).to(classOf[connectors.VatRegAuthConnector])
     bind(classOf[connectors.BusinessRegistrationConnector]).to(classOf[connectors.VatRegBusinessRegistrationConnector])
     bind(classOf[services.RegistrationService]).to(classOf[services.VatRegistrationService])

--- a/app/controllers/test/TestSupportController.scala
+++ b/app/controllers/test/TestSupportController.scala
@@ -21,9 +21,8 @@ import javax.inject.Inject
 import auth.Authenticated
 import connectors.test.BusinessRegistrationTestConnector
 import connectors.{AuthConnector, BusinessRegistrationConnector}
-import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent}
-import services.RegistrationService
+import repositories.test.TestOnlyRepository
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -34,7 +33,7 @@ class TestSupportController @Inject()(
                                        val auth: AuthConnector,
                                        brConnector: BusinessRegistrationConnector,
                                        brTestConnector: BusinessRegistrationTestConnector,
-                                       registrationService: RegistrationService
+                                       testOnlyRepository: TestOnlyRepository
                                      ) extends BaseController with Authenticated {
   // $COVERAGE-OFF$
 
@@ -50,9 +49,10 @@ class TestSupportController @Inject()(
 
   def dropCollection(): Action[AnyContent] = Action.async { implicit request =>
     authenticated { user =>
-      registrationService.dropCollection
+      testOnlyRepository.dropCollection
       Future.successful(Ok("Collection Dropped"))
     }
   }
+
   // $COVERAGE-ON$
 }

--- a/app/repositories/RegistrationMongoRepository.scala
+++ b/app/repositories/RegistrationMongoRepository.scala
@@ -31,6 +31,7 @@ import uk.gov.hmrc.mongo.ReactiveRepository
 import scala.concurrent.Future
 
 trait RegistrationRepository {
+
   def createNewVatScheme(registrationId: String): Future[VatScheme]
 
   def retrieveVatScheme(registrationId: String): Future[Option[VatScheme]]
@@ -43,7 +44,6 @@ trait RegistrationRepository {
 
   def deleteVatScheme(registrationId: String): Future[Boolean]
 
-  def dropCollection: Future[Unit]
 }
 
 // this is here for Guice dependency injection of `() => DB`
@@ -110,10 +110,4 @@ class RegistrationMongoRepository @Inject()(mongoProvider: Function0[DB], @Named
     }
   }
 
-  // $COVERAGE-OFF$
-  override def dropCollection: Future[Unit] = {
-    collection.drop()
-  }
-
-  // $COVERAGE-ON$
 }

--- a/app/repositories/test/TestOnlyRepository.scala
+++ b/app/repositories/test/TestOnlyRepository.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories.test
+
+import javax.inject.{Inject, Named}
+
+import models.VatScheme
+import reactivemongo.api.DB
+import reactivemongo.api.indexes.{Index, IndexType}
+import reactivemongo.bson.BSONObjectID
+import uk.gov.hmrc.mongo.ReactiveRepository
+
+import scala.concurrent.Future
+
+trait TestOnlyRepository {
+  def dropCollection(): Future[Unit]
+}
+
+
+class TestOnlyMongoRepository @Inject()(mongoProvider: Function0[DB], @Named("collectionName") collectionName: String)
+  extends ReactiveRepository[VatScheme, BSONObjectID](
+    collectionName = collectionName,
+    mongo = mongoProvider,
+    domainFormat = VatScheme.format
+  ) with TestOnlyRepository {
+
+  // $COVERAGE-OFF$
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  override def indexes: Seq[Index] = Seq(Index(
+    name = Some("RegId"),
+    key = Seq("registrationId" -> IndexType.Ascending),
+    unique = true
+  ))
+
+  override def dropCollection(): Future[Unit] = collection.drop()
+
+  // $COVERAGE-ON$
+
+}
+

--- a/app/services/VatRegistrationService.scala
+++ b/app/services/VatRegistrationService.scala
@@ -43,8 +43,6 @@ trait RegistrationService {
 
   def deleteVatScheme(registrationId: String): ServiceResult[Boolean]
 
-  def dropCollection: Future[Unit]
-
 }
 
 class VatRegistrationService @Inject()(brConnector: BusinessRegistrationConnector,
@@ -91,7 +89,5 @@ class VatRegistrationService @Inject()(brConnector: BusinessRegistrationConnecto
 
   override def deleteVatScheme(registrationId: String): ServiceResult[Boolean] =
     toEitherT(registrationRepository.deleteVatScheme(registrationId))
-
-  override def dropCollection: Future[Unit] = { registrationRepository.dropCollection }
 
 }

--- a/conf/test.routes
+++ b/conf/test.routes
@@ -1,3 +1,3 @@
 POST        /current-profile-setup        controllers.test.TestSupportController.currentProfileSetup()
-GET         /clear                        controllers.test.TestSupportController.dropCollection()
+POST        /clear                        controllers.test.TestSupportController.dropCollection()
 


### PR DESCRIPTION
invoked by an HTTP POST
test-only controller skips service layer and goes to test-only
repository directly to drop the collection
moved dropping collection methods out of real repository/service