### PR TITLE
SAR-7576/SAR-8758 return VAT2 in the attachments list if Partnership

### DIFF
--- a/app/models/api/AttachmentType.scala
+++ b/app/models/api/AttachmentType.scala
@@ -52,7 +52,7 @@ object AttachmentType {
     Writes[AttachmentType](attachmentType => JsString(map(attachmentType)))
   )
 
-  def submissionWrites(attachmentOption: AttachmentMethod): Writes[List[AttachmentType]] = Writes { attachments =>
+  def submissionWrites(attachmentOption: AttachmentMethod): Writes[Set[AttachmentType]] = Writes { attachments =>
     Json.toJson(
       attachments.map { attachmentType =>
         map(attachmentType) -> {

--- a/test/mocks/MockAttachmentsService.scala
+++ b/test/mocks/MockAttachmentsService.scala
@@ -32,7 +32,7 @@ trait MockAttachmentsService extends MockitoSugar {
   val mockAttachmentService: AttachmentsService = mock[AttachmentsService]
 
   def mockGetAttachmentList(internalId: String)
-                           (response: Future[List[AttachmentType]]): OngoingStubbing[Future[List[AttachmentType]]] =
+                           (response: Future[Set[AttachmentType]]): OngoingStubbing[Future[Set[AttachmentType]]] =
     when(mockAttachmentService.getAttachmentList(ArgumentMatchers.eq(internalId)))
       .thenReturn(response)
 

--- a/test/models/api/AttachmentTypeSpec.scala
+++ b/test/models/api/AttachmentTypeSpec.scala
@@ -34,7 +34,7 @@ class AttachmentTypeSpec extends VatRegSpec with VatRegistrationFixture {
 
   "AttachmentType submissionWrites" must {
     "parse a list of AttachmentTypes to the correct Json" in {
-      Json.toJson[List[AttachmentType]](List(LetterOfAuthority, VAT51))(AttachmentType.submissionWrites(Post)) mustBe Json.obj(
+      Json.toJson[Set[AttachmentType]](Set(LetterOfAuthority, VAT51))(AttachmentType.submissionWrites(Post)) mustBe Json.obj(
         "letterOfAuthority" -> "3",
         "VAT51" -> "3"
       )

--- a/test/services/submission/AdminBlockBuilderSpec.scala
+++ b/test/services/submission/AdminBlockBuilderSpec.scala
@@ -19,7 +19,7 @@ package services.submission
 import fixtures.VatRegistrationFixture
 import helpers.VatRegSpec
 import mocks.MockAttachmentsService
-import models.api.{AttachmentMethod, Attachments, EmailMethod, IdentityEvidence, Post}
+import models.api.{AttachmentMethod, AttachmentType, Attachments, EmailMethod, IdentityEvidence, Post}
 import models.submission.NETP
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
@@ -68,7 +68,7 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
         when(mockRegistrationMongoRepository.retrieveTradingDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Some(validFullTradingDetails)))
         when(mockAttachmentService.getAttachmentList(ArgumentMatchers.eq(testRegId)))
-          .thenReturn(Future.successful(Nil))
+          .thenReturn(Future.successful(Set[AttachmentType]()))
         when(mockAttachmentService.getAttachmentDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Some(Attachments(Post))))
 
@@ -83,7 +83,7 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
         when(mockRegistrationMongoRepository.retrieveTradingDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Some(validFullTradingDetails)))
         when(mockAttachmentService.getAttachmentList(ArgumentMatchers.eq(testRegId)))
-          .thenReturn(Future.successful(List(IdentityEvidence)))
+          .thenReturn(Future.successful(Set[AttachmentType](IdentityEvidence)))
         when(mockAttachmentService.getAttachmentDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Some(Attachments(Post))))
 
@@ -98,7 +98,7 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
         when(mockRegistrationMongoRepository.retrieveTradingDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Some(validFullTradingDetails)))
         when(mockAttachmentService.getAttachmentList(ArgumentMatchers.eq(testRegId)))
-          .thenReturn(Future.successful(List(IdentityEvidence)))
+          .thenReturn(Future.successful(Set[AttachmentType](IdentityEvidence)))
         when(mockAttachmentService.getAttachmentDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Some(Attachments(EmailMethod))))
 
@@ -115,7 +115,7 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
         when(mockRegistrationMongoRepository.retrieveTradingDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Some(validFullTradingDetails)))
         when(mockAttachmentService.getAttachmentList(ArgumentMatchers.eq(testRegId)))
-          .thenReturn(Future.successful(Nil))
+          .thenReturn(Future.successful(Set[AttachmentType]()))
         when(mockAttachmentService.getAttachmentDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Some(Attachments(Post))))
 
@@ -130,7 +130,7 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
         when(mockRegistrationMongoRepository.retrieveTradingDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(None))
         when(mockAttachmentService.getAttachmentList(ArgumentMatchers.eq(testRegId)))
-          .thenReturn(Future.successful(Nil))
+          .thenReturn(Future.successful(Set[AttachmentType]()))
         when(mockAttachmentService.getAttachmentDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Some(Attachments(Post))))
 
@@ -145,7 +145,7 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
         when(mockRegistrationMongoRepository.retrieveTradingDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(None))
         when(mockAttachmentService.getAttachmentList(ArgumentMatchers.eq(testRegId)))
-          .thenReturn(Future.successful(Nil))
+          .thenReturn(Future.successful(Set[AttachmentType]()))
         when(mockAttachmentService.getAttachmentDetails(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Some(Attachments(Post))))
 


### PR DESCRIPTION
SAR-7576/SAR-8758 Update attachments service to return VAT2 in the list if party type is partnership (excluding LLP)

**New feature**

## Checklist

* [x] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
