### PR TITLE
SAR-9199 Edited FormerName Object To Store hasFormerName Boolean

### DIFF
--- a/app/models/api/FormerName.scala
+++ b/app/models/api/FormerName.scala
@@ -16,19 +16,14 @@
 
 package models.api
 
+import play.api.libs.json._
+
 import java.time.LocalDate
 
-import play.api.libs.json._
-import play.api.libs.functional.syntax._
-
-case class FormerName(name: Option[Name],
+case class FormerName(hasFormerName: Option[Boolean], //TODO: Remove optionality from boolean in 2 weeks (24/3/22)
+                      name: Option[Name],
                       change: Option[LocalDate])
 
 object FormerName {
   implicit val format = Json.format[FormerName]
-
-  val auditWrites: Format[FormerName] = (
-    (__).formatNullable[Name](Name.auditWrites) and
-    (__ \ "nameChangeDate").formatNullable[LocalDate]
-  )(FormerName.apply, unlift(FormerName.unapply))
 }

--- a/app/services/submission/DeclarationBlockBuilder.scala
+++ b/app/services/submission/DeclarationBlockBuilder.scala
@@ -49,7 +49,9 @@ class DeclarationBlockBuilder @Inject()(registrationMongoRepository: VatSchemeRe
               "applicantDetails" -> jsonObject(
                 "roleInBusiness" -> applicantDetails.roleInBusiness,
                 "name" -> formatName(applicantDetails.personalDetails.name),
-                optional("prevName" -> applicantDetails.changeOfName.map(formatFormerName)),
+                conditional(applicantDetails.changeOfName.exists(_.hasFormerName.contains(true)))(
+                  "prevName" -> applicantDetails.changeOfName.map(formatFormerName)
+                ),
                 optionalRequiredIf(applicantDetails.personalDetails.arn.isEmpty)("dateOfBirth" -> applicantDetails.personalDetails.dateOfBirth),
                 "currAddress" -> formatAddress(applicantDetails.currentAddress),
                 optional("prevAddress" -> applicantDetails.previousAddress.map(formatAddress)),

--- a/it/itutil/ITFixtures.scala
+++ b/it/itutil/ITFixtures.scala
@@ -111,7 +111,7 @@ trait ITFixtures {
   val testRole = Director
   val testName = Name(first = Some("Forename"), middle = None, last = "Surname")
   val testProperName = Name(first = Some(testFirstName), middle = None, last = testLastName)
-  val testFormerName = FormerName(name = Some(oldName), change = Some(testDate))
+  val testFormerName = FormerName(hasFormerName = Some(true), name = Some(oldName), change = Some(testDate))
   val testCompanyName = "testCompanyName"
   val testDateOfBirth = DateOfBirth(testDate)
   val testCrn = "testCrn"

--- a/test/fixtures/VatRegistrationFixture.scala
+++ b/test/fixtures/VatRegistrationFixture.scala
@@ -51,7 +51,7 @@ trait VatRegistrationFixture {
   lazy val testSicCode = SicCode("88888", "description", "displayDetails")
   lazy val testName = Name(first = Some("Forename"), middle = None, last = "Surname")
   lazy val testOldName = Name(first = Some("Bob"), middle = None, last = "Smith")
-  lazy val testPreviousName = FormerName(name = Some(testOldName), change = Some(testDate))
+  lazy val testPreviousName = FormerName(hasFormerName = Some(true), name = Some(testOldName), change = Some(testDate))
   lazy val testVatScheme: VatScheme = VatScheme(testRegId, internalId = testInternalId, status = VatRegStatus.draft)
   lazy val exception = new Exception("Exception")
   lazy val testVoluntaryThreshold = Threshold(mandatoryRegistration = false, None, None, None)
@@ -71,7 +71,7 @@ trait VatRegistrationFixture {
   lazy val testBic = "010203"
   lazy val testIban = "01023456"
   lazy val testBankDetailsOverseas = BankAccountOverseasDetails(testOverseasBankName, testBic, testIban)
-  lazy val testFormerName = FormerName(Some(testName), Some(testDate))
+  lazy val testFormerName = FormerName(hasFormerName = Some(true), Some(testName), Some(testDate))
   lazy val testReturns = Returns(Some(12.99), reclaimVatOnMostReturns = false, Quarterly, JanuaryStagger, Some(testDate), None, None, None)
   lazy val zeroRatedSupplies: BigDecimal = 12.99
   lazy val testBpSafeId = "testBpSafeId"


### PR DESCRIPTION
# SAR-9199 Edited FormerName Object To Store hasFormerName Separately

hasFormerName is now stored so that the pre-population for SAR-9199 works on the front end. 

## Checklist

* [ ] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
