### PR TITLE
SAR-9528 - expose get all upscan details endpoint

### DIFF
--- a/app/controllers/UpscanController.scala
+++ b/app/controllers/UpscanController.scala
@@ -58,6 +58,14 @@ class UpscanController @Inject()(controllerComponents: ControllerComponents,
     }
   }
 
+  def getAllUpscanDetails(regId: String): Action[AnyContent] = Action.async { implicit request =>
+    isAuthorised(regId) { authResult =>
+      authResult.ifAuthorised(regId, "UpscanController", "getUpscanDetails") {
+        upscanService.getAllUpscanDetails(regId).map(upscanDetails => Ok(Json.toJson(upscanDetails)))
+      }
+    }
+  }
+
   def upscanDetailsCallback: Action[UpscanDetails] = Action.async(parse.json[UpscanDetails]) { implicit request =>
     upscanService.getUpscanDetails(request.body.reference).flatMap {
       case Some(details) =>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -56,6 +56,7 @@ PATCH       /:regId/nrs-payload                     controllers.NrsSubmissionPay
 
 POST        /:regId/upscan-reference                controllers.UpscanController.createUpscanDetails(regId: String)
 GET         /:regId/upscan-file-details/:reference  controllers.UpscanController.getUpscanDetails(regId: String, reference: String)
+GET         /:regId/upscan-file-details             controllers.UpscanController.getAllUpscanDetails(regId: String)
 DELETE      /:regId/upscan-file-details/:reference  controllers.UpscanController.deleteUpscanDetails(regId: String, reference: String)
 DELETE      /:regId/upscan-file-details             controllers.UpscanController.deleteAllUpscanDetails(regId: String)
 POST        /upscan-callback                        controllers.UpscanController.upscanDetailsCallback


### PR DESCRIPTION
[SAR-9528] Expose get all upscan details endpoint to display in summary page (covered as part of [SAR-9490](https://jira.tools.tax.service.gov.uk/browse/SAR-9490))

New feature

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
