### PR TITLE
SAR-9549|Change attachment service rules to remove netp/overseas checks

### DIFF
--- a/app/services/AttachmentsService.scala
+++ b/app/services/AttachmentsService.scala
@@ -70,9 +70,8 @@ class AttachmentsService @Inject()(val registrationRepository: VatSchemeReposito
     registrationRepository.updateBlock[Attachments](regId, attachmentDetails, attachmentDetailsKey)
 
   private def getIdentityEvidenceAttachment(vatScheme: VatScheme): Option[IdentityEvidence.type] = {
-    val needIdentityDoc = vatScheme.eligibilitySubmissionData.exists(data => List(NETP, NonUkNonEstablished).contains(data.partyType))
     val unverifiedPersonalDetails = vatScheme.applicantDetails.exists(data => !data.personalDetails.identifiersMatch)
-    if (needIdentityDoc || unverifiedPersonalDetails) Some(IdentityEvidence) else None
+    if (unverifiedPersonalDetails) Some(IdentityEvidence) else None
   }
 
   private def getTransactorIdentityEvidenceAttachment(vatScheme: VatScheme): Option[TransactorIdentityEvidence.type] = {

--- a/test/services/AttachmentsServiceSpec.scala
+++ b/test/services/AttachmentsServiceSpec.scala
@@ -31,8 +31,6 @@ class AttachmentsServiceSpec extends VatRegSpec with VatRegistrationFixture with
   object Service extends AttachmentsService(mockVatSchemeRepository, mockUpscanMongoRepository)
 
   val attachmentsKey = "attachments"
-  val netpEligibilityData = testEligibilitySubmissionData.copy(partyType = NETP)
-  val testNetpVatScheme = testVatScheme.copy(eligibilitySubmissionData = Some(netpEligibilityData))
   val testUnverifiedUserVatScheme = testFullVatScheme.copy(
     applicantDetails = Some(unverifiedUserApplicantDetails)
   )
@@ -56,13 +54,6 @@ class AttachmentsServiceSpec extends VatRegSpec with VatRegistrationFixture with
 
   "getAttachmentsList" when {
     "attachments are required" must {
-      "return a list of the required attachments for a NETP" in {
-        mockGetVatScheme(testRegId)(Some(testNetpVatScheme))
-
-        val res = await(Service.getAttachmentList(testRegId))
-
-        res mustBe Set(IdentityEvidence)
-      }
 
       "return a list of the required attachments for a UKCompany with unmatched personal details" in {
         mockGetVatScheme(testRegId)(Some(testUnverifiedUserVatScheme))


### PR DESCRIPTION
[SAR-9549](https://jira.tools.tax.service.gov.uk/browse/SAR-9549)

**Bug fix**

[VRS] Update attachment service rules to remove netp/overseas checks for id documents, only identifiersMatch should be checked

## Checklist

* [X] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
