### PR TITLE
SAR-9901 | New data block for vat-application, to replace returns

### DIFF
--- a/app/controllers/ReturnsController.scala
+++ b/app/controllers/ReturnsController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import auth.{Authorisation, AuthorisationResource}
-import models.api.returns.Returns
+import models.api.vatapplication.Returns
 import play.api.libs.json.JsValue
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.ReturnsService

--- a/app/models/api/vatapplication/AASDetails.scala
+++ b/app/models/api/vatapplication/AASDetails.scala
@@ -14,22 +14,13 @@
  * limitations under the License.
  */
 
-package services
+package models.api.vatapplication
 
-import models.api.vatapplication.Returns
-import repositories.VatSchemeRepository
+import play.api.libs.json.{Format, Json}
 
-import javax.inject.{Inject, Singleton}
-import scala.concurrent.Future
+case class AASDetails(paymentMethod: PaymentMethod,
+                      paymentFrequency: PaymentFrequency)
 
-@Singleton
-class ReturnsService @Inject()(val registrationRepository: VatSchemeRepository) {
-
-  def retrieveReturns(regId: String): Future[Option[Returns]] = {
-    registrationRepository.fetchReturns(regId)
-  }
-
-  def updateReturns(regId: String, returns: Returns): Future[Returns] = {
-    registrationRepository.updateReturns(regId, returns)
-  }
+object AASDetails {
+  implicit val format: Format[AASDetails] = Json.format[AASDetails]
 }

--- a/app/models/api/vatapplication/NIPCompliance.scala
+++ b/app/models/api/vatapplication/NIPCompliance.scala
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-package services
+package models.api.vatapplication
 
-import models.api.vatapplication.Returns
-import repositories.VatSchemeRepository
+import play.api.libs.json.{Json, OFormat}
 
-import javax.inject.{Inject, Singleton}
-import scala.concurrent.Future
+case class NIPCompliance(goodsToEU: ConditionalValue,
+                         goodsFromEU: ConditionalValue)
 
-@Singleton
-class ReturnsService @Inject()(val registrationRepository: VatSchemeRepository) {
+object NIPCompliance {
+  implicit val format: OFormat[NIPCompliance] = Json.format[NIPCompliance]
+}
 
-  def retrieveReturns(regId: String): Future[Option[Returns]] = {
-    registrationRepository.fetchReturns(regId)
-  }
+case class ConditionalValue(answer: Boolean,
+                            value: Option[BigDecimal])
 
-  def updateReturns(regId: String, returns: Returns): Future[Returns] = {
-    registrationRepository.updateReturns(regId, returns)
-  }
+object ConditionalValue {
+  implicit val format: OFormat[ConditionalValue] = Json.format[ConditionalValue]
 }

--- a/app/models/api/vatapplication/OverseasCompliance.scala
+++ b/app/models/api/vatapplication/OverseasCompliance.scala
@@ -14,20 +14,17 @@
  * limitations under the License.
  */
 
-package models.api.returns
+package models.api.vatapplication
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Format, Json}
 
-case class NIPCompliance(goodsToEU: ConditionalValue,
-                         goodsFromEU: ConditionalValue)
+case class OverseasCompliance(goodsToOverseas: Boolean,
+                              goodsToEu: Option[Boolean],
+                              storingGoodsForDispatch: StoringGoodsForDispatch,
+                              usingWarehouse: Option[Boolean],
+                              fulfilmentWarehouseNumber: Option[String],
+                              fulfilmentWarehouseName: Option[String])
 
-object NIPCompliance {
-  implicit val format: OFormat[NIPCompliance] = Json.format[NIPCompliance]
-}
-
-case class ConditionalValue(answer: Boolean,
-                            value: Option[BigDecimal])
-
-object ConditionalValue {
-  implicit val format: OFormat[ConditionalValue] = Json.format[ConditionalValue]
+object OverseasCompliance {
+  implicit val format: Format[OverseasCompliance] = Json.format[OverseasCompliance]
 }

--- a/app/models/api/vatapplication/PaymentFrequency.scala
+++ b/app/models/api/vatapplication/PaymentFrequency.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package models.api.returns
+package models.api.vatapplication
 
 import play.api.libs.json._
 

--- a/app/models/api/vatapplication/PaymentMethod.scala
+++ b/app/models/api/vatapplication/PaymentMethod.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package models.api.returns
+package models.api.vatapplication
 
 import play.api.libs.json._
 

--- a/app/models/api/vatapplication/Returns.scala
+++ b/app/models/api/vatapplication/Returns.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package models.api.returns
+package models.api.vatapplication
 
 import play.api.libs.json._
 import utils.JsonUtilities
@@ -35,24 +35,6 @@ case class Returns(turnoverEstimate: Option[BigDecimal],
 
 object Returns extends JsonUtilities {
   implicit val format: Format[Returns] = Json.format[Returns]
-}
-
-case class AASDetails(paymentMethod: PaymentMethod,
-                      paymentFrequency: PaymentFrequency)
-
-object AASDetails {
-  implicit val format: Format[AASDetails] = Json.format[AASDetails]
-}
-
-case class OverseasCompliance(goodsToOverseas: Boolean,
-                              goodsToEu: Option[Boolean],
-                              storingGoodsForDispatch: StoringGoodsForDispatch,
-                              usingWarehouse: Option[Boolean],
-                              fulfilmentWarehouseNumber: Option[String],
-                              fulfilmentWarehouseName: Option[String])
-
-object OverseasCompliance {
-  implicit val format: Format[OverseasCompliance] = Json.format[OverseasCompliance]
 }
 
 sealed trait StoringGoodsForDispatch

--- a/app/models/api/vatapplication/ReturnsFrequency.scala
+++ b/app/models/api/vatapplication/ReturnsFrequency.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package models.api.returns
+package models.api.vatapplication
 
 import play.api.libs.json._
 

--- a/app/models/api/vatapplication/Stagger.scala
+++ b/app/models/api/vatapplication/Stagger.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package models.api.returns
+package models.api.vatapplication
 
 import play.api.libs.json._
 

--- a/app/models/api/vatapplication/VatApplication.scala
+++ b/app/models/api/vatapplication/VatApplication.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.api.vatapplication
+
+import utils.JsonUtilities
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+
+import java.time.LocalDate
+
+case class VatApplication(eoriRequested: Option[Boolean],
+                          tradeVatGoodsOutsideUk: Option[Boolean],
+                          turnoverEstimate: Option[BigDecimal],
+                          appliedForExemption: Option[Boolean],
+                          zeroRatedSupplies: Option[BigDecimal],
+                          claimVatRefunds: Option[Boolean],
+                          returnsFrequency: Option[ReturnsFrequency],
+                          staggerStart: Option[Stagger],
+                          startDate: Option[LocalDate],
+                          annualAccountingDetails: Option[AASDetails],
+                          overseasCompliance: Option[OverseasCompliance],
+                          northernIrelandProtocol: Option[NIPCompliance],
+                          hasTaxRepresentative: Option[Boolean])
+
+object VatApplication extends JsonUtilities {
+
+  val tempReads: Reads[VatApplication] = (
+    (__ \ "tradingDetails" \ "eoriRequested").readNullable[Boolean] and
+      (__ \ "tradingDetails" \ "tradeVatGoodsOutsideUk").readNullable[Boolean] and
+      (__ \ "returns" \ "turnoverEstimate").readNullable[BigDecimal] and
+      (__ \ "returns" \ "appliedForExemption").readNullable[Boolean] and
+      (__ \ "returns" \ "zeroRatedSupplies").readNullable[BigDecimal] and
+      (__ \ "returns" \ "reclaimVatOnMostReturns").readNullable[Boolean] and
+      (__ \ "returns" \ "returnsFrequency").readNullable[ReturnsFrequency] and
+      (__ \ "returns" \ "staggerStart").readNullable[Stagger] and
+      (__ \ "returns" \ "startDate").readNullable[LocalDate] and
+      (__ \ "returns" \ "annualAccountingDetails").readNullable[AASDetails] and
+      (__ \ "returns" \ "overseasCompliance").readNullable[OverseasCompliance] and
+      (__ \ "returns" \ "northernIrelandProtocol").readNullable[NIPCompliance] and
+      (__ \ "returns" \ "hasTaxRepresentative").readNullable[Boolean]
+    ) (VatApplication.apply _)
+
+  implicit val format: Format[VatApplication] = Json.format[VatApplication]
+}

--- a/app/models/monitoring/SubmissionAuditModel.scala
+++ b/app/models/monitoring/SubmissionAuditModel.scala
@@ -41,8 +41,8 @@ case class SubmissionAuditModel(userAnswers: JsValue,
   override val transactionName: String = "subscription-submitted"
 
   override val detail: JsValue =
-    (vatScheme.eligibilitySubmissionData, vatScheme.tradingDetails, vatScheme.applicantDetails, vatScheme.returns) match {
-      case (Some(eligibilityData), Some(tradingDetails), Some(applicantDetails), Some(returns)) =>
+    (vatScheme.eligibilitySubmissionData, vatScheme.applicantDetails, vatScheme.vatApplication) match {
+      case (Some(eligibilityData), Some(applicantDetails), Some(vatApplication)) =>
         jsonObject(
           "authProviderId" -> authProviderId,
           "journeyId" -> vatScheme.id,
@@ -54,11 +54,11 @@ case class SubmissionAuditModel(userAnswers: JsValue,
           conditional(List(NETP, NonUkNonEstablished).contains(eligibilityData.partyType))(
             "overseasTrader" -> true
           ),
-          "eoriRequested" -> tradingDetails.eoriRequested,
+          "eoriRequested" -> vatApplication.eoriRequested,
           "registrationReason" -> eligibilityData.registrationReason.humanReadableKey,
           optional("registrationRelevantDate" -> {
             eligibilityData.registrationReason match {
-              case Voluntary | SuppliesOutsideUk | GroupRegistration | IntendingTrader => returns.startDate
+              case Voluntary | SuppliesOutsideUk | GroupRegistration | IntendingTrader => vatApplication.startDate
               case NonUk => eligibilityData.threshold.thresholdOverseas
               case TransferOfAGoingConcern => eligibilityData.togcCole.map(_.dateOfTransfer)
               case _ => Some(eligibilityData.threshold.earliestDate)
@@ -87,9 +87,8 @@ case class SubmissionAuditModel(userAnswers: JsValue,
           [SubmissionAuditModel] Could not construct Audit JSON as required blocks are missing.
 
           eligibilitySubmissionData is present?   ${vatScheme.eligibilitySubmissionData.isDefined}
-          tradingDetails is present?              ${vatScheme.tradingDetails.isDefined}
           applicantDetails is present?            ${vatScheme.applicantDetails.isDefined}
-          returns is present?                     ${vatScheme.returns.isDefined}
+          vatApplication is present?              ${vatScheme.vatApplication.isDefined}
         """)
     }
 

--- a/app/models/registration/RegistrationSectionId.scala
+++ b/app/models/registration/RegistrationSectionId.scala
@@ -74,6 +74,11 @@ case object BusinessSectionId extends RegistrationSectionId {
   val repoKey = "business"
 }
 
+case object VatApplicationSectionId extends RegistrationSectionId {
+  val key = "vatApplication"
+  val repoKey = key
+}
+
 object RegistrationSectionId {
   // scalastyle:off
   implicit def urlBinder(implicit stringBinder: PathBindable[String]): PathBindable[RegistrationSectionId] =
@@ -93,6 +98,7 @@ object RegistrationSectionId {
             case ("section", TradingDetailsSectionId.key) => Right(TradingDetailsSectionId)
             case ("section", OtherBusinessInvolvementsSectionId.key) => Right(OtherBusinessInvolvementsSectionId)
             case ("section", BusinessSectionId.key) => Right(BusinessSectionId)
+            case ("section", VatApplicationSectionId.key) => Right(VatApplicationSectionId)
             case _ => Left("Invalid registration section")
           }
         } yield section

--- a/app/services/AttachmentsService.scala
+++ b/app/services/AttachmentsService.scala
@@ -94,7 +94,7 @@ class AttachmentsService @Inject()(val registrationRepository: VatSchemeReposito
   }
 
   private def getTaxRepresentativeAttachment(vatScheme: VatScheme): Option[TaxRepresentativeAuthorisation.type] = {
-    vatScheme.returns.flatMap(_.hasTaxRepresentative) match {
+    vatScheme.vatApplication.flatMap(_.hasTaxRepresentative) match {
       case Some(hasTaxRepresentative) if hasTaxRepresentative => Some(TaxRepresentativeAuthorisation)
       case _ => None
     }

--- a/app/services/EligibilityService.scala
+++ b/app/services/EligibilityService.scala
@@ -87,16 +87,17 @@ class EligibilityService @Inject()(val registrationRepository: VatSchemeReposito
               partners = None,
               attachments = None,
               otherBusinessInvolvements = None,
-              business = None
+              business = None,
+              vatApplication = None
             ))
 
           case EligibilitySubmissionData(_, _, _, _, _, oldTransactorFlag, _)
             if !oldTransactorFlag.equals(eligibilityData.isTransactor) || eligibilityData.appliedForException.contains(true) =>
 
-            val returnsWithClearedExemption = if (eligibilityData.appliedForException.contains(true)) {
-              vatScheme.returns.map(_.copy(appliedForExemption = None))
+            val vatApplicationWithClearedExemption = if (eligibilityData.appliedForException.contains(true)) {
+              vatScheme.vatApplication.map(_.copy(appliedForExemption = None))
             } else {
-              vatScheme.returns
+              vatScheme.vatApplication
             }
 
             val clearedTransactor = if (oldTransactorFlag != eligibilityData.isTransactor) {
@@ -107,7 +108,7 @@ class EligibilityService @Inject()(val registrationRepository: VatSchemeReposito
 
             registrationRepository.insertVatScheme(vatScheme.copy(
               transactorDetails = clearedTransactor,
-              returns = returnsWithClearedExemption
+              vatApplication = vatApplicationWithClearedExemption
             ))
 
           case _ =>

--- a/app/services/SectionValidationService.scala
+++ b/app/services/SectionValidationService.scala
@@ -17,7 +17,7 @@
 package services
 
 import models.api._
-import models.api.returns.Returns
+import models.api.vatapplication.{Returns, VatApplication}
 import models.registration._
 import models.registration.sections.PartnersSection
 import models.submission.PartyType
@@ -53,6 +53,7 @@ class SectionValidationService @Inject()(registrationService: RegistrationServic
       case TradingDetailsSectionId => Future(validate[TradingDetails](json))
       case OtherBusinessInvolvementsSectionId => Future(validate[List[OtherBusinessInvolvement]](json))
       case BusinessSectionId => Future(validate[Business](json))
+      case VatApplicationSectionId => Future(validate[VatApplication](json))
       case unknown => throw new InternalServerException(s"[SectionValidationService] Attempted to validate an unsupported section: ${unknown.toString}")
     }
 

--- a/app/services/monitoring/AnnualAccountingAuditBlockBuilder.scala
+++ b/app/services/monitoring/AnnualAccountingAuditBlockBuilder.scala
@@ -18,7 +18,7 @@ package services.monitoring
 
 import models._
 import models.api.VatScheme
-import models.api.returns.Annual
+import models.api.vatapplication.Annual
 import play.api.libs.json.JsObject
 import utils.JsonUtils._
 
@@ -28,19 +28,19 @@ import javax.inject.{Inject, Singleton}
 class AnnualAccountingAuditBlockBuilder @Inject()() {
 
   def buildAnnualAccountingAuditBlock(vatScheme: VatScheme): Option[JsObject] = {
-    (vatScheme.returns, vatScheme.eligibilitySubmissionData) match {
-      case (Some(returns), Some(eligibilitySubmissionData)) if returns.returnsFrequency.equals(Annual) =>
+    (vatScheme.vatApplication, vatScheme.eligibilitySubmissionData) match {
+      case (Some(vatApplication), Some(eligibilitySubmissionData)) if vatApplication.returnsFrequency.contains(Annual) =>
         Some(jsonObject(
           "submissionType" -> "1",
-          "customerRequest" -> returns.annualAccountingDetails.map { details =>
+          "customerRequest" -> vatApplication.annualAccountingDetails.map { details =>
             jsonObject(
               "paymentMethod" -> details.paymentMethod,
-              "annualStagger" -> returns.staggerStart,
+              "annualStagger" -> vatApplication.staggerStart,
               "paymentFrequency" -> details.paymentFrequency,
-              "estimatedTurnover" -> returns.turnoverEstimate,
+              "estimatedTurnover" -> vatApplication.turnoverEstimate,
               "reqStartDate" -> {
                 eligibilitySubmissionData.registrationReason match {
-                  case Voluntary | SuppliesOutsideUk | IntendingTrader => returns.startDate
+                  case Voluntary | SuppliesOutsideUk | IntendingTrader => vatApplication.startDate
                   case BackwardLook => eligibilitySubmissionData.threshold.thresholdInTwelveMonths
                   case ForwardLook => Some(eligibilitySubmissionData.threshold.earliestDate)
                   case NonUk => eligibilitySubmissionData.threshold.thresholdOverseas

--- a/app/services/monitoring/PeriodsAuditBlockBuilder.scala
+++ b/app/services/monitoring/PeriodsAuditBlockBuilder.scala
@@ -27,11 +27,11 @@ import javax.inject.Singleton
 class PeriodsAuditBlockBuilder {
 
   def buildPeriodsBlock(vatScheme: VatScheme): JsObject = {
-    vatScheme.returns match {
-      case Some(returns) =>
-        jsonObject("customerPreferredPeriodicity" -> returns.staggerStart)
+    vatScheme.vatApplication match {
+      case Some(vatApplication) =>
+        jsonObject("customerPreferredPeriodicity" -> vatApplication.staggerStart)
       case None =>
-        throw new InternalServerException("[PeriodsBlockBuilder]: Couldn't build periods section due to missing returns section in vat scheme")
+        throw new InternalServerException("[PeriodsBlockBuilder]: Couldn't build periods section due to missing vat application section in vat scheme")
     }
   }
 }

--- a/app/services/monitoring/SubmissionAuditBlockBuilder.scala
+++ b/app/services/monitoring/SubmissionAuditBlockBuilder.scala
@@ -47,7 +47,7 @@ class SubmissionAuditBlockBuilder @Inject()(subscriptionBlockBuilder: Subscripti
     val attachmentList = attachmentsService.attachmentList(vatScheme)
     val details = jsonObject(
       "outsideEUSales" -> {
-        vatScheme.tradingDetails.map(_.eoriRequested) match {
+        vatScheme.vatApplication.map(_.eoriRequested) match {
           case Some(euGoods) => euGoods
           case _ => throw new InternalServerException("Could not construct submission audit JSON due to missing EU goods answer")
         }

--- a/app/services/submission/AdminBlockBuilder.scala
+++ b/app/services/submission/AdminBlockBuilder.scala
@@ -32,8 +32,8 @@ class AdminBlockBuilder @Inject()(attachmentsService: AttachmentsService) {
 
   def buildAdminBlock(vatScheme: VatScheme): JsObject = {
     val attachmentList = attachmentsService.attachmentList(vatScheme)
-    (vatScheme.eligibilitySubmissionData, vatScheme.tradingDetails) match {
-      case (Some(eligibilityData), Some(tradingDetails)) =>
+    (vatScheme.eligibilitySubmissionData, vatScheme.vatApplication) match {
+      case (Some(eligibilityData), Some(vatApplication)) =>
         jsonObject(
           "additionalInformation" -> jsonObject(
             "customerStatus" -> MTDfB,
@@ -42,7 +42,7 @@ class AdminBlockBuilder @Inject()(attachmentsService: AttachmentsService) {
             )
           ),
           "attachments" -> (jsonObject(
-            optional("EORIrequested" -> tradingDetails.eoriRequested)) ++ {
+            optional("EORIrequested" -> vatApplication.eoriRequested)) ++ {
             vatScheme.attachments.map(_.method) match {
               case Some(attachmentMethod) => AttachmentType.submissionWrites(attachmentMethod).writes(attachmentList).as[JsObject]
               case None => Json.obj()
@@ -52,7 +52,7 @@ class AdminBlockBuilder @Inject()(attachmentsService: AttachmentsService) {
       case (None, Some(_)) =>
         throw new InternalServerException("Could not build admin block for submission due to missing eligibility data")
       case (Some(_), None) =>
-        throw new InternalServerException("Could not build admin block for submission due to missing trading details data")
+        throw new InternalServerException("Could not build admin block for submission due to missing vat application data")
       case _ =>
         throw new InternalServerException("Could not build admin block for submission due to no available data")
     }

--- a/app/services/submission/AnnualAccountingBlockBuilder.scala
+++ b/app/services/submission/AnnualAccountingBlockBuilder.scala
@@ -18,7 +18,7 @@ package services.submission
 
 import models._
 import models.api.VatScheme
-import models.api.returns.Annual
+import models.api.vatapplication.Annual
 import play.api.libs.json.JsObject
 import utils.JsonUtils.{jsonObject, required}
 
@@ -28,19 +28,19 @@ import javax.inject.{Inject, Singleton}
 class AnnualAccountingBlockBuilder @Inject()() {
 
   def buildAnnualAccountingBlock(vatScheme: VatScheme): Option[JsObject] =
-    (vatScheme.returns, vatScheme.eligibilitySubmissionData) match {
-      case (Some(returns), Some(eligibilitySubmissionData)) if returns.returnsFrequency.equals(Annual) =>
+    (vatScheme.vatApplication, vatScheme.eligibilitySubmissionData) match {
+      case (Some(vatApplication), Some(eligibilitySubmissionData)) if vatApplication.returnsFrequency.contains(Annual) =>
         Some(jsonObject(
           "submissionType" -> "1",
-          "customerRequest" -> returns.annualAccountingDetails.map { details =>
+          "customerRequest" -> vatApplication.annualAccountingDetails.map { details =>
             jsonObject(
               "paymentMethod" -> details.paymentMethod,
-              "annualStagger" -> returns.staggerStart,
+              "annualStagger" -> vatApplication.staggerStart,
               "paymentFrequency" -> details.paymentFrequency,
-              required("estimatedTurnover" -> returns.turnoverEstimate),
+              required("estimatedTurnover" -> vatApplication.turnoverEstimate),
               "reqStartDate" -> {
                 eligibilitySubmissionData.registrationReason match {
-                  case Voluntary | SuppliesOutsideUk | IntendingTrader => returns.startDate
+                  case Voluntary | SuppliesOutsideUk | IntendingTrader => vatApplication.startDate
                   case BackwardLook => eligibilitySubmissionData.threshold.thresholdInTwelveMonths
                   case ForwardLook => Some(eligibilitySubmissionData.threshold.earliestDate)
                   case NonUk => eligibilitySubmissionData.threshold.thresholdOverseas

--- a/app/services/submission/PeriodsBlockBuilder.scala
+++ b/app/services/submission/PeriodsBlockBuilder.scala
@@ -27,11 +27,11 @@ import javax.inject.{Inject, Singleton}
 class PeriodsBlockBuilder @Inject()() {
 
   def buildPeriodsBlock(vatScheme: VatScheme): JsObject =
-    vatScheme.returns match {
-      case Some(returns) =>
-        jsonObject("customerPreferredPeriodicity" -> returns.staggerStart)
+    vatScheme.vatApplication match {
+      case Some(vatApplication) =>
+        jsonObject("customerPreferredPeriodicity" -> vatApplication.staggerStart)
       case None =>
-        throw new InternalServerException("Couldn't build periods section due to missing returns section in vat scheme")
+        throw new InternalServerException("Couldn't build periods section due to missing vat application section in vat scheme")
     }
 
 }

--- a/app/services/submission/SubmissionService.scala
+++ b/app/services/submission/SubmissionService.scala
@@ -21,7 +21,7 @@ import connectors.VatSubmissionConnector
 import enums.VatRegStatus
 import featureswitch.core.config.FeatureSwitching
 import httpparsers.VatSubmissionHttpParser.VatSubmissionResponse
-import models.api.returns.Annual
+import models.api.vatapplication.Annual
 import models.api.{Attached, PersonalDetails, Submitted, VatScheme}
 import play.api.Logging
 import play.api.http.Status.{BAD_REQUEST, CONFLICT}
@@ -176,15 +176,15 @@ class SubmissionService @Inject()(registrationRepository: VatSchemeRepository,
       case _ => None
     }
 
-    val exceptionOrExemption = (vatScheme.eligibilitySubmissionData, vatScheme.returns) match {
-      case (Some(eligibilityData), Some(returns)) => VatScheme.exceptionOrExemption(eligibilityData, returns) match {
+    val exceptionOrExemption = (vatScheme.eligibilitySubmissionData, vatScheme.vatApplication) match {
+      case (Some(eligibilityData), Some(vatApplication)) => VatScheme.exceptionOrExemption(eligibilityData, vatApplication) match {
         case VatScheme.exceptionKey => Some("Exception")
         case VatScheme.exemptionKey => Some("Exemption")
         case _ => None
       }
       case _ => None
     }
-    val appliedForAas = if (vatScheme.returns.map(_.returnsFrequency).contains(Annual)) Some("AnnualAccountingScheme") else None
+    val appliedForAas = if (vatScheme.vatApplication.flatMap(_.returnsFrequency).contains(Annual)) Some("AnnualAccountingScheme") else None
     val appliedForFrs = if (vatScheme.flatRateScheme.exists(_.joinFrs)) Some("FlatRateScheme") else None
     val hasObi = if (vatScheme.otherBusinessInvolvements.exists(_.nonEmpty)) Some("OtherBusinessInvolvements") else None
     val specialSituations = List(exceptionOrExemption, appliedForAas, appliedForFrs, hasObi).flatten

--- a/it/controllers/ReturnsControllerISpec.scala
+++ b/it/controllers/ReturnsControllerISpec.scala
@@ -3,7 +3,7 @@
 package controllers
 
 import itutil.{FakeTimeMachine, IntegrationStubbing}
-import models.api.returns._
+import models.api.vatapplication._
 import play.api.Application
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder

--- a/it/itutil/ITFixtures.scala
+++ b/it/itutil/ITFixtures.scala
@@ -19,7 +19,7 @@ package itutil
 import enums.VatRegStatus
 import models._
 import models.api._
-import models.api.returns._
+import models.api.vatapplication._
 import models.sdes.PropertyExtractor._
 import models.sdes._
 import models.submission._
@@ -75,6 +75,21 @@ trait ITFixtures {
     hasTaxRepresentative = Some(false)
   )
 
+  val testVatApplication: VatApplication = VatApplication(
+    Some(true), Some(true),
+    turnoverEstimate = Some(testTurnover),
+    appliedForExemption = None,
+    zeroRatedSupplies = Some(12.99),
+    claimVatRefunds = Some(true),
+    returnsFrequency = Some(Quarterly),
+    staggerStart = Some(JanuaryStagger),
+    startDate = Some(startDate),
+    annualAccountingDetails = None,
+    overseasCompliance = None,
+    northernIrelandProtocol = Some(testNorthernIrelandProtocol),
+    hasTaxRepresentative = Some(false)
+  )
+
   val frsDetails = FRSDetails(
     businessGoods = Some(BusinessGoods(12345678L, true)),
     startDate = Some(testDate),
@@ -83,7 +98,7 @@ trait ITFixtures {
     limitedCostTrader = Some(false)
   )
 
-  val aasDetails = returns.AASDetails(
+  val aasDetails = vatapplication.AASDetails(
     paymentMethod = StandingOrder,
     paymentFrequency = MonthlyPayment
   )
@@ -101,6 +116,22 @@ trait ITFixtures {
     northernIrelandProtocol = Some(testNorthernIrelandProtocol),
     hasTaxRepresentative = Some(false)
   )
+
+  val testAASVatApplicationDetails: VatApplication = VatApplication(
+    Some(true), Some(true),
+    turnoverEstimate = Some(testTurnover),
+    appliedForExemption = None,
+    zeroRatedSupplies = Some(12.99),
+    claimVatRefunds = Some(true),
+    returnsFrequency = Some(Annual),
+    staggerStart = Some(JanDecStagger),
+    startDate = Some(startDate),
+    annualAccountingDetails = Some(aasDetails),
+    overseasCompliance = None,
+    northernIrelandProtocol = Some(testNorthernIrelandProtocol),
+    hasTaxRepresentative = Some(false)
+  )
+
   lazy val testFirstName = "testFirstName"
   lazy val testLastName = "testLastName"
   val testFlatRateScheme = FlatRateScheme(joinFrs = true, Some(frsDetails))
@@ -286,7 +317,7 @@ trait ITFixtures {
     applicantDetails = Some(testUnregisteredApplicantDetails),
     eligibilitySubmissionData = Some(testEligibilitySubmissionData),
     confirmInformationDeclaration = Some(true),
-    returns = Some(testReturns),
+    vatApplication = Some(testVatApplication),
     nrsSubmissionPayload = Some(testEncodedPayload),
     business = Some(testBusiness)
   )
@@ -296,7 +327,7 @@ trait ITFixtures {
       id = testRegId,
       internalId = testInternalid,
       tradingDetails = Some(testTradingDetails),
-      returns = Some(testAASReturns),
+      vatApplication = Some(testAASVatApplicationDetails),
       bankAccount = Some(BankAccount(isProvided = true, Some(testBankDetails), None, None)),
       acknowledgementReference = Some("ackRef"),
       flatRateScheme = Some(testFlatRateScheme),
@@ -331,7 +362,7 @@ trait ITFixtures {
       internalId = testInternalid,
       tradingDetails = Some(testTradingDetails),
       transactorDetails = Some(testAgentTransactorDetails),
-      returns = Some(testAASReturns),
+      vatApplication = Some(testAASVatApplicationDetails),
       bankAccount = Some(BankAccount(isProvided = true, Some(testBankDetails), None, None)),
       acknowledgementReference = Some("ackRef"),
       flatRateScheme = Some(testFlatRateScheme),
@@ -348,7 +379,7 @@ trait ITFixtures {
       id = testRegId,
       internalId = testInternalid,
       tradingDetails = Some(testTradingDetails),
-      returns = Some(testReturns),
+      vatApplication = Some(testVatApplication),
       bankAccount = Some(BankAccount(isProvided = false, None, None, Some(BeingSetup))),
       acknowledgementReference = Some("ackRef"),
       flatRateScheme = Some(FlatRateScheme(joinFrs = false, None)),
@@ -548,6 +579,28 @@ trait ITFixtures {
     hasTaxRepresentative = Some(false)
   )
 
+  val testNetpVatApplication: VatApplication = VatApplication(
+    None, None,
+    turnoverEstimate = Some(testTurnover),
+    appliedForExemption = None,
+    zeroRatedSupplies = Some(12.99),
+    claimVatRefunds = Some(true),
+    returnsFrequency = Some(Quarterly),
+    staggerStart = Some(JanuaryStagger),
+    startDate = None,
+    annualAccountingDetails = None,
+    overseasCompliance = Some(OverseasCompliance(
+      true,
+      Some(true),
+      StoringWithinUk,
+      Some(true),
+      Some(testWarehouseNumber),
+      Some(testWarehouseName)
+    )),
+    None,
+    hasTaxRepresentative = Some(false)
+  )
+
   val testNetpTradingDetails: TradingDetails = TradingDetails(
     Some(testTradingName),
     None,
@@ -610,7 +663,7 @@ trait ITFixtures {
       applicantDetails = Some(testNetpApplicantDetails),
       bankAccount = None,
       eligibilitySubmissionData = Some(testNetpEligibilitySubmissionData),
-      returns = Some(testNetpReturns),
+      vatApplication = Some(testNetpVatApplication),
       tradingDetails = Some(testNetpTradingDetails),
       flatRateScheme = None,
       attachments = Some(Attachments(Post)),

--- a/it/itutil/ITVatSubmissionFixture.scala
+++ b/it/itutil/ITVatSubmissionFixture.scala
@@ -1,7 +1,7 @@
 
 package itutil
 
-import models.api.returns.{StoringGoodsForDispatch, StoringWithinUk}
+import models.api.vatapplication.{StoringGoodsForDispatch, StoringWithinUk}
 import models.api.{AttachmentMethod, AttachmentType, Post}
 import models.submission._
 import models.{ForwardLook, RegistrationReason}

--- a/it/repository/VatSchemeRepositoryISpec.scala
+++ b/it/repository/VatSchemeRepositoryISpec.scala
@@ -20,7 +20,7 @@ import common.exceptions._
 import enums.VatRegStatus
 import itutil._
 import models.api._
-import models.api.returns._
+import models.api.vatapplication._
 import org.mongodb.scala.MongoWriteException
 import org.mongodb.scala.model.Filters.{equal => mongoEqual}
 import org.mongodb.scala.result.InsertOneResult
@@ -84,6 +84,24 @@ class VatSchemeRepositoryISpec extends MongoBaseSpec with IntegrationStubbing wi
     reclaimVatOnMostReturns = true,
     returnsFrequency = Quarterly,
     staggerStart = JanuaryStagger,
+    startDate = Some(testDate),
+    northernIrelandProtocol = Some(NIPCompliance(
+      goodsToEU = ConditionalValue(true, Some(testTurnover)),
+      goodsFromEU = ConditionalValue(true, Some(testTurnover))
+    )),
+    appliedForExemption = None,
+    annualAccountingDetails = None,
+    overseasCompliance = None,
+    hasTaxRepresentative = Some(false)
+  )
+
+  val vatApplication = VatApplication(
+    None, None,
+    turnoverEstimate = Some(testTurnover),
+    zeroRatedSupplies = Some(12.99),
+    claimVatRefunds = Some(true),
+    returnsFrequency = Some(Quarterly),
+    staggerStart = Some(JanuaryStagger),
     startDate = Some(testDate),
     northernIrelandProtocol = Some(NIPCompliance(
       goodsToEU = ConditionalValue(true, Some(testTurnover)),
@@ -307,14 +325,14 @@ class VatSchemeRepositoryISpec extends MongoBaseSpec with IntegrationStubbing wi
 
       await(repository.updateReturns(testRegId, returns))
 
-      getRegistration mustBe Some(testVatScheme.copy(returns = Some(returns)))
+      getRegistration mustBe Some(testVatScheme.copy(returns = Some(returns), vatApplication = Some(vatApplication)))
     }
     "not update or insert new data into the registration doc if the supplied returns already exist on the doc" in new Setup {
       await(insert(testVatScheme.copy(returns = Some(returns))))
 
       await(repository.updateReturns(testRegId, returns))
 
-      getRegistration mustBe Some(testVatScheme.copy(returns = Some(returns)))
+      getRegistration mustBe Some(testVatScheme.copy(returns = Some(returns), vatApplication = Some(vatApplication)))
     }
     "return MissingRegDocument when nothing is returned from mongo for the reg id" in new Setup {
       count mustBe 0

--- a/it/services/SubmissionAuditBlockBuilderISpec.scala
+++ b/it/services/SubmissionAuditBlockBuilderISpec.scala
@@ -18,7 +18,7 @@ class SubmissionAuditBlockBuilderISpec extends IntegrationStubbing with Submissi
     applicantDetails = Some(testUnregisteredApplicantDetails),
     eligibilitySubmissionData = Some(testEligibilitySubmissionData),
     confirmInformationDeclaration = Some(true),
-    returns = Some(testAASReturns),
+    vatApplication = Some(testAASVatApplicationDetails),
     nrsSubmissionPayload = Some(testEncodedPayload),
     otherBusinessInvolvements = Some(List(
       testOtherBusinessInvolvement.copy(

--- a/test/controllers/ReturnsControllerSpec.scala
+++ b/test/controllers/ReturnsControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import fixtures.VatRegistrationFixture
 import helpers.VatRegSpec
-import models.api.returns.{AASDetails, Annual, BankGIRO, JanDecStagger, MonthlyPayment, PaymentFrequency, PaymentMethod, Returns, ReturnsFrequency, Stagger}
+import models.api.vatapplication.{AASDetails, Annual, BankGIRO, JanDecStagger, MonthlyPayment, PaymentFrequency, PaymentMethod, Returns, ReturnsFrequency, Stagger}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.libs.json.{JsObject, Json}

--- a/test/fixtures/VatRegistrationFixture.scala
+++ b/test/fixtures/VatRegistrationFixture.scala
@@ -19,7 +19,7 @@ package fixtures
 import enums.VatRegStatus
 import models._
 import models.api._
-import models.api.returns._
+import models.api.vatapplication._
 import models.submission._
 import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.auth.core.AffinityGroup
@@ -75,6 +75,10 @@ trait VatRegistrationFixture {
   lazy val testFormerName = FormerName(hasFormerName = Some(true), Some(testName), Some(testDate))
   lazy val testReturns = Returns(
     Some(testTurnover), None, Some(12.99), reclaimVatOnMostReturns = false, Quarterly, JanuaryStagger, Some(testDate), None, None, None, None
+  )
+  lazy val testVatApplicationDetails = VatApplication(
+    Some(true), Some(true), Some(testTurnover), None, Some(12.99), Some(false), Some(Quarterly),
+    Some(JanuaryStagger), Some(testDate), None, None, None, None
   )
   lazy val zeroRatedSupplies: BigDecimal = 12.99
   lazy val testBpSafeId = "testBpSafeId"
@@ -230,9 +234,35 @@ trait VatRegistrationFixture {
     None
   )
 
+  lazy val validAASApplicationDeatils: VatApplication = VatApplication(
+    Some(true), Some(true),
+    Some(testTurnover),
+    None,
+    Some(12.99),
+    claimVatRefunds = Some(false),
+    Some(Annual),
+    Some(JanDecStagger),
+    Some(testDate),
+    Some(validAASDetails),
+    None,
+    None,
+    None
+  )
+
   val testWarehouseNumber = "test12345678"
   val testWarehouseName = "testWarehouseName"
   val testOverseasReturns: Returns = testReturns.copy(
+    startDate = None,
+    overseasCompliance = Some(OverseasCompliance(
+      goodsToOverseas = true,
+      goodsToEu = Some(true),
+      storingGoodsForDispatch = StoringWithinUk,
+      usingWarehouse = Some(true),
+      fulfilmentWarehouseNumber = Some(testWarehouseNumber),
+      fulfilmentWarehouseName = Some(testWarehouseName)
+    )))
+
+  val testOverseasVatApplicationDetails: VatApplication = testVatApplicationDetails.copy(
     startDate = None,
     overseasCompliance = Some(OverseasCompliance(
       goodsToOverseas = true,
@@ -298,7 +328,8 @@ trait VatRegistrationFixture {
     confirmInformationDeclaration = Some(true),
     returns = Some(testReturns),
     nrsSubmissionPayload = Some(testEncodedPayload),
-    business = Some(testBusiness)
+    business = Some(testBusiness),
+    vatApplication = Some(testVatApplicationDetails)
   )
 
   lazy val validFullTradingDetails: TradingDetails = TradingDetails(tradingName = Some(testTradingName), eoriRequested = Some(true), None, Some(true))

--- a/test/models/VatApplicationSpec.scala
+++ b/test/models/VatApplicationSpec.scala
@@ -17,12 +17,12 @@
 package models
 
 import helpers.BaseSpec
-import models.api.vatapplication._
-import play.api.libs.json.{__, _}
+import models.api.vatapplication.{AASDetails, Annual, BankGIRO, ConditionalValue, JanDecStagger, JanuaryStagger, Monthly, MonthlyPayment, MonthlyStagger, NIPCompliance, OverseasCompliance, PaymentFrequency, PaymentMethod, Quarterly, ReturnsFrequency, Stagger, StoringGoodsForDispatch, StoringWithinUk, VatApplication}
+import play.api.libs.json._
 
 import java.time.LocalDate
 
-class ReturnsSpec extends BaseSpec with JsonFormatValidation {
+class VatApplicationSpec extends BaseSpec with JsonFormatValidation {
 
   val testTurnover = 10000.5
   val testDate: LocalDate = LocalDate.now()
@@ -33,13 +33,15 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
     ConditionalValue(answer = false, None)
   )
 
-  val testMonthlyReturns: Returns = Returns(
+  val testMonthlyVatApplication: VatApplication = VatApplication(
+    Some(true),
+    Some(true),
     Some(testTurnover),
     None,
     Some(testTurnover),
-    reclaimVatOnMostReturns = true,
-    Monthly,
-    MonthlyStagger,
+    claimVatRefunds = Some(true),
+    Some(Monthly),
+    Some(MonthlyStagger),
     Some(testDate),
     None,
     None,
@@ -47,13 +49,15 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
     Some(false)
   )
 
-  val testQuarterlyReturns: Returns = Returns(
+  val testQuarterlyVatApplication: VatApplication = VatApplication(
+    Some(true),
+    Some(true),
     Some(testTurnover),
     None,
     Some(testTurnover),
-    reclaimVatOnMostReturns = false,
-    Quarterly,
-    JanuaryStagger,
+    claimVatRefunds = Some(false),
+    Some(Quarterly),
+    Some(JanuaryStagger),
     Some(testDate),
     None,
     None,
@@ -61,13 +65,15 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
     None
   )
 
-  val testAnnualReturns: Returns = Returns(
+  val testAnnualVatApplication: VatApplication = VatApplication(
+    Some(true),
+    Some(true),
     Some(testTurnover),
     None,
     Some(testTurnover),
-    reclaimVatOnMostReturns = false,
-    Annual,
-    JanDecStagger,
+    claimVatRefunds = Some(false),
+    Some(Annual),
+    Some(JanDecStagger),
     Some(testDate),
     Some(AASDetails(BankGIRO, MonthlyPayment)),
     None,
@@ -75,7 +81,7 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
     None
   )
 
-  val testOverseasReturns: Returns = testQuarterlyReturns.copy(overseasCompliance = Some(OverseasCompliance(
+  val testOverseasVatApplication: VatApplication = testQuarterlyVatApplication.copy(overseasCompliance = Some(OverseasCompliance(
     goodsToOverseas = true,
     goodsToEu = Some(true),
     storingGoodsForDispatch = StoringWithinUk,
@@ -84,10 +90,12 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
     fulfilmentWarehouseName = Some(testWarehouseName)
   )))
 
-  val validMonthlyReturnsJson: JsObject = Json.obj(
+  val validMonthlyVatApplicationJson: JsObject = Json.obj(
+    "eoriRequested" -> true,
+    "tradeVatGoodsOutsideUk" -> true,
     "turnoverEstimate" -> testTurnover,
     "zeroRatedSupplies" -> testTurnover,
-    "reclaimVatOnMostReturns" -> true,
+    "claimVatRefunds" -> true,
     "returnsFrequency" -> Json.toJson[ReturnsFrequency](Monthly),
     "staggerStart" -> Json.toJson[Stagger](MonthlyStagger),
     "startDate" -> testDate,
@@ -103,10 +111,12 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
     "hasTaxRepresentative" -> false
   )
 
-  val validQuarterlyReturnsJson: JsObject = Json.obj(
+  val validQuarterlyVatApplicationJson: JsObject = Json.obj(
+    "eoriRequested" -> true,
+    "tradeVatGoodsOutsideUk" -> true,
     "turnoverEstimate" -> testTurnover,
     "zeroRatedSupplies" -> testTurnover,
-    "reclaimVatOnMostReturns" -> false,
+    "claimVatRefunds" -> false,
     "returnsFrequency" -> Json.toJson[ReturnsFrequency](Quarterly),
     "staggerStart" -> Json.toJson[Stagger](JanuaryStagger),
     "startDate" -> testDate,
@@ -121,11 +131,13 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
     )
   )
 
-  def validAnnualReturnsJson(startDate: Option[LocalDate] = Some(testDate)): JsObject =
+  def validAnnualVatApplicationJson(startDate: Option[LocalDate] = Some(testDate)): JsObject =
     Json.obj(
+      "eoriRequested" -> true,
+      "tradeVatGoodsOutsideUk" -> true,
       "turnoverEstimate" -> testTurnover,
       "zeroRatedSupplies" -> testTurnover,
-      "reclaimVatOnMostReturns" -> false,
+      "claimVatRefunds" -> false,
       "returnsFrequency" -> Json.toJson[ReturnsFrequency](Annual),
       "staggerStart" -> Json.toJson[Stagger](JanDecStagger),
       "startDate" -> startDate,
@@ -144,7 +156,9 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
       )
     )
 
-  val invalidReturnsJson: JsObject = Json.obj(
+  val invalidVatApplicationJson: JsObject = Json.obj(
+    "eoriRequested" -> true,
+    "tradeVatGoodsOutsideUk" -> true,
     "turnoverEstimate" -> testTurnover,
     "zeroRatedSupplies" -> testTurnover,
     "returnsFrequency" -> "invalidFrequency",
@@ -166,9 +180,11 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
   )
 
   val validOverseasJson: JsObject = Json.obj(
+    "eoriRequested" -> true,
+    "tradeVatGoodsOutsideUk" -> true,
     "turnoverEstimate" -> testTurnover,
     "zeroRatedSupplies" -> testTurnover,
-    "reclaimVatOnMostReturns" -> false,
+    "claimVatRefunds" -> false,
     "returnsFrequency" -> Json.toJson[ReturnsFrequency](Quarterly),
     "staggerStart" -> Json.toJson[Stagger](JanuaryStagger),
     "startDate" -> testDate,
@@ -191,34 +207,33 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
     )
   )
 
-  "Parsing Returns" should {
+  "Parsing VatApplication" should {
     "succeed" when {
       "full monthly json is present" in {
-        Json.fromJson[Returns](validMonthlyReturnsJson) mustBe JsSuccess(testMonthlyReturns)
+        Json.fromJson[VatApplication](validMonthlyVatApplicationJson) mustBe JsSuccess(testMonthlyVatApplication)
       }
 
       "full quarterly json is present" in {
-        Json.fromJson[Returns](validQuarterlyReturnsJson) mustBe JsSuccess(testQuarterlyReturns)
+        Json.fromJson[VatApplication](validQuarterlyVatApplicationJson) mustBe JsSuccess(testQuarterlyVatApplication)
       }
 
       "full annual json is present" in {
-        Json.fromJson[Returns](validAnnualReturnsJson()) mustBe JsSuccess(testAnnualReturns)
+        Json.fromJson[VatApplication](validAnnualVatApplicationJson()) mustBe JsSuccess(testAnnualVatApplication)
       }
 
       "full annual json is present without startDate" in {
-        Json.fromJson[Returns](validAnnualReturnsJson(None)) mustBe JsSuccess(testAnnualReturns.copy(startDate = None))
+        Json.fromJson[VatApplication](validAnnualVatApplicationJson(None)) mustBe JsSuccess(testAnnualVatApplication.copy(startDate = None))
       }
 
       "full overseas json is present" in {
-        Json.fromJson[Returns](validOverseasJson) mustBe JsSuccess(testOverseasReturns)
+        Json.fromJson[VatApplication](validOverseasJson) mustBe JsSuccess(testOverseasVatApplication)
       }
     }
 
     "fails" when {
       "json is invalid" in {
-        val result = Json.fromJson[Returns](invalidReturnsJson)
+        val result = Json.fromJson[VatApplication](invalidVatApplicationJson)
         result shouldHaveErrors(
-          __ \ "reclaimVatOnMostReturns" -> JsonValidationError("error.path.missing"),
           __ \ "returnsFrequency" -> JsonValidationError("Could not parse payment frequency"),
           __ \ "staggerStart" -> JsonValidationError("Could not parse Stagger")
         )
@@ -226,10 +241,10 @@ class ReturnsSpec extends BaseSpec with JsonFormatValidation {
     }
   }
 
-  "Returns model to json" should {
+  "VatApplication model to json" should {
     "succeed" when {
       "everything is present" in {
-        Json.toJson[Returns](testAnnualReturns) mustBe validAnnualReturnsJson()
+        Json.toJson[VatApplication](testAnnualVatApplication) mustBe validAnnualVatApplicationJson()
       }
     }
   }

--- a/test/models/api/VatSchemeSpec.scala
+++ b/test/models/api/VatSchemeSpec.scala
@@ -25,13 +25,13 @@ class VatSchemeSpec extends VatRegSpec with VatRegistrationFixture {
   "exceptionOrExemption" must {
     "return exceptionKey" when {
       "eligibilitySubmissionData has appliedForException flag true" in {
-        val result = VatScheme.exceptionOrExemption(testEligibilitySubmissionData.copy(appliedForException = Some(true)), testReturns)
+        val result = VatScheme.exceptionOrExemption(testEligibilitySubmissionData.copy(appliedForException = Some(true)), testVatApplicationDetails)
         result mustBe VatScheme.exceptionKey
       }
     }
     "return exemptionKey" when {
       "Returns has appliedForExemption flag true" in {
-        val result = VatScheme.exceptionOrExemption(testEligibilitySubmissionData, testReturns.copy(appliedForExemption = Some(true)))
+        val result = VatScheme.exceptionOrExemption(testEligibilitySubmissionData, testVatApplicationDetails.copy(appliedForExemption = Some(true)))
         result mustBe VatScheme.exemptionKey
       }
     }
@@ -39,13 +39,13 @@ class VatSchemeSpec extends VatRegSpec with VatRegistrationFixture {
       "both exception and exemption flags are false" in {
         val result = VatScheme.exceptionOrExemption(
           testEligibilitySubmissionData.copy(appliedForException = Some(false)),
-          testReturns.copy(appliedForExemption = Some(false)))
+          testVatApplicationDetails.copy(appliedForExemption = Some(false)))
         result mustBe VatScheme.nonExceptionOrExemptionKey
       }
       "both exception and exemption flags are not present" in {
         val result = VatScheme.exceptionOrExemption(
           testEligibilitySubmissionData.copy(appliedForException = None),
-          testReturns.copy(appliedForExemption = None))
+          testVatApplicationDetails.copy(appliedForExemption = None))
         result mustBe VatScheme.nonExceptionOrExemptionKey
       }
     }
@@ -54,7 +54,7 @@ class VatSchemeSpec extends VatRegSpec with VatRegistrationFixture {
         intercept[InternalServerException] {
           VatScheme.exceptionOrExemption(
             testEligibilitySubmissionData.copy(appliedForException = Some(true)),
-            testReturns.copy(appliedForExemption = Some(true)))
+            testVatApplicationDetails.copy(appliedForExemption = Some(true)))
         }
       }
     }

--- a/test/models/monitoring/SubmissionAuditModelSpec.scala
+++ b/test/models/monitoring/SubmissionAuditModelSpec.scala
@@ -36,7 +36,7 @@ class SubmissionAuditModelSpec extends VatRegSpec with SubmissionAuditFixture {
     eligibilitySubmissionData = Some(testEligibilitySubmissionData),
     tradingDetails = Some(validFullTradingDetails),
     applicantDetails = Some(validApplicantDetails),
-    returns = Some(testReturns)
+    vatApplication = Some(testVatApplicationDetails)
   )
 
   def model(vatScheme: VatScheme): SubmissionAuditModel = SubmissionAuditModel(
@@ -172,24 +172,10 @@ class SubmissionAuditModelSpec extends VatRegSpec with SubmissionAuditFixture {
         }
       }
     }
-    "the trading details block is missing in the vat scheme" should {
-      "throw an exception" in {
-        intercept[InternalServerException] {
-          model(rootBlockTestVatScheme.copy(tradingDetails = None))
-        }
-      }
-    }
     "the applicant details block is missing in the vat scheme" should {
       "throw an exception" in {
         intercept[InternalServerException] {
           model(rootBlockTestVatScheme.copy(applicantDetails = None))
-        }
-      }
-    }
-    "the returns block is missing in the vat scheme" should {
-      "throw an exception" in {
-        intercept[InternalServerException] {
-          model(rootBlockTestVatScheme.copy(returns = None))
         }
       }
     }

--- a/test/services/AttachmentsServiceSpec.scala
+++ b/test/services/AttachmentsServiceSpec.scala
@@ -51,7 +51,7 @@ class AttachmentsServiceSpec extends VatRegSpec with VatRegistrationFixture with
   val vatGroupEligibilityData = testEligibilitySubmissionData.copy(registrationReason = GroupRegistration)
   val testVatGroupVatScheme = testVatScheme.copy(eligibilitySubmissionData = Some(vatGroupEligibilityData))
   val testLnpVatScheme = testVatScheme.copy(business = Some(testBusiness.copy(hasLandAndProperty = Some(true))))
-  val testSchemeWithTaxRepresentative = testVatScheme.copy(returns = Some(testReturns.copy(hasTaxRepresentative = Some(true))))
+  val testSchemeWithTaxRepresentative = testVatScheme.copy(vatApplication = Some(testVatApplicationDetails.copy(hasTaxRepresentative = Some(true))))
 
   "getAttachmentsList" when {
     "attachments are required" must {

--- a/test/services/EligibilityServiceSpec.scala
+++ b/test/services/EligibilityServiceSpec.scala
@@ -138,12 +138,12 @@ class EligibilityServiceSpec extends VatRegSpec with VatRegistrationFixture {
 
       val vatSchemeWithExemption: VatScheme = testFullVatScheme
         .copy(
-          returns = Some(testReturns.copy(appliedForExemption = Some(true))),
+          vatApplication = Some(testVatApplicationDetails.copy(appliedForExemption = Some(true))),
           eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(appliedForException = Some(false)))
         )
       val vatSchemeWithoutExemption: VatScheme = vatSchemeWithExemption
         .copy(
-          returns = Some(testReturns.copy(appliedForExemption = None))
+          vatApplication = Some(testVatApplicationDetails.copy(appliedForExemption = None))
         )
       when(mockRegistrationMongoRepository.updateEligibilitySubmissionData(any(), any()))
         .thenReturn(Future.successful(testEligibilitySubmissionData.copy(appliedForException = Some(true))))

--- a/test/services/ReturnsServiceSpec.scala
+++ b/test/services/ReturnsServiceSpec.scala
@@ -18,7 +18,7 @@ package services
 
 import fixtures.VatRegistrationFixture
 import helpers.VatRegSpec
-import models.api.returns.Returns
+import models.api.vatapplication.Returns
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import play.api.test.Helpers._

--- a/test/services/SectionValidationServiceSpec.scala
+++ b/test/services/SectionValidationServiceSpec.scala
@@ -96,6 +96,14 @@ class SectionValidationServiceSpec extends VatRegSpec
         res mustBe Right(ValidSection(data))
       }
     }
+    "the section is VatApplication" must {
+      "return ValidSection when the data is valid" in {
+        val data = Json.toJson(testVatApplicationDetails)
+        val res = await(Service.validate(testInternalId, testRegId, VatApplicationSectionId, data))
+
+        res mustBe Right(ValidSection(data))
+      }
+    }
     "the section is Transactor" must {
       "return ValidSection when the data is valid" in {
         val data = Json.toJson(validTransactorDetails)

--- a/test/services/monitoring/AnnualAccountingAuditBlockBuilderSpec.scala
+++ b/test/services/monitoring/AnnualAccountingAuditBlockBuilderSpec.scala
@@ -40,7 +40,7 @@ class AnnualAccountingAuditBlockBuilderSpec extends VatRegSpec with VatRegistrat
   "buildAnnualAccountingBlock" should {
     "return the correct json" when {
       "the applicant wants to join AAS and all data is provided" in {
-        val testScheme = testVatScheme.copy(returns = Some(validAASReturns), eligibilitySubmissionData = Some(testEligibilitySubmissionData))
+        val testScheme = testVatScheme.copy(vatApplication = Some(validAASApplicationDeatils), eligibilitySubmissionData = Some(testEligibilitySubmissionData))
 
         val res = TestBuilder.buildAnnualAccountingAuditBlock(testScheme)
 

--- a/test/services/monitoring/PeriodsAuditBlockBuilderSpec.scala
+++ b/test/services/monitoring/PeriodsAuditBlockBuilderSpec.scala
@@ -18,7 +18,7 @@ package services.monitoring
 
 import fixtures.VatRegistrationFixture
 import helpers.VatRegSpec
-import models.api.returns._
+import models.api.vatapplication._
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.InternalServerException
 
@@ -28,7 +28,8 @@ class PeriodsAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
 
   "the periods block builder" should {
     "write the correct json for the monthly stagger" in {
-      val testScheme = testVatScheme.copy(returns = Some(testReturns).map(_.copy(returnsFrequency = Monthly, staggerStart = MonthlyStagger))
+      val testScheme = testVatScheme.copy(
+        vatApplication = Some(testVatApplicationDetails).map(_.copy(returnsFrequency = Some(Monthly), staggerStart = Some(MonthlyStagger)))
       )
 
       val res = TestBuilder.buildPeriodsBlock(testScheme)
@@ -38,7 +39,9 @@ class PeriodsAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
       )
     }
     "write the correct json for stagger 1" in {
-      val testScheme = testVatScheme.copy(returns = Some(testReturns).map(_.copy(staggerStart = JanuaryStagger)))
+      val testScheme = testVatScheme.copy(
+        vatApplication = Some(testVatApplicationDetails).map(_.copy(staggerStart = Some(JanuaryStagger)))
+      )
 
       val res = TestBuilder.buildPeriodsBlock(testScheme)
 
@@ -47,7 +50,9 @@ class PeriodsAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
       )
     }
     "write the correct json for stagger 2" in {
-      val testScheme = testVatScheme.copy(returns = Some(testReturns).map(_.copy(staggerStart = FebruaryStagger)))
+      val testScheme = testVatScheme.copy(
+        vatApplication = Some(testVatApplicationDetails).map(_.copy(staggerStart = Some(FebruaryStagger)))
+      )
 
       val res = TestBuilder.buildPeriodsBlock(testScheme)
 
@@ -56,7 +61,9 @@ class PeriodsAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
       )
     }
     "write the correct json for stagger 3" in {
-      val testScheme = testVatScheme.copy(returns = Some(testReturns).map(_.copy(staggerStart = MarchStagger)))
+      val testScheme = testVatScheme.copy(
+        vatApplication = Some(testVatApplicationDetails).map(_.copy(staggerStart = Some(MarchStagger)))
+      )
 
       val res = TestBuilder.buildPeriodsBlock(testScheme)
 
@@ -65,7 +72,7 @@ class PeriodsAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
       )
     }
     "throw an exception if the returns section is missing" in {
-      val testScheme = testVatScheme.copy(returns = None)
+      val testScheme = testVatScheme.copy(vatApplication = None)
 
       intercept[InternalServerException] {
         TestBuilder.buildPeriodsBlock(testScheme)

--- a/test/services/monitoring/SubscriptionAuditBlockBuilderSpec.scala
+++ b/test/services/monitoring/SubscriptionAuditBlockBuilderSpec.scala
@@ -19,7 +19,7 @@ package services.monitoring
 import fixtures.VatRegistrationFixture
 import helpers.VatRegSpec
 import models.api._
-import models.api.returns.{JanuaryStagger, Quarterly, Returns}
+import models.api.vatapplication.{JanuaryStagger, Quarterly, VatApplication}
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.http.InternalServerException
 
@@ -90,13 +90,15 @@ class SubscriptionAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationF
 
   "buildSubscriptionBlock" should {
     val testDate = LocalDate.of(2020, 2, 2)
-    val testReturns = Returns(
+    val testVatApplicationDetails = VatApplication(
+      None,
+      None,
       Some(testTurnover),
       None,
       Some(12.99),
-      reclaimVatOnMostReturns = false,
-      Quarterly,
-      JanuaryStagger,
+      claimVatRefunds = Some(false),
+      Some(Quarterly),
+      Some(JanuaryStagger),
       Some(testDate),
       None,
       None,
@@ -108,7 +110,7 @@ class SubscriptionAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationF
       val vatScheme = testVatScheme.copy(
         eligibilitySubmissionData = Some(testEligibilitySubmissionData),
         business = Some(testBusiness),
-        returns = Some(testReturns),
+        vatApplication = Some(testVatApplicationDetails),
         flatRateScheme = Some(validFullFlatRateScheme)
       )
 
@@ -123,7 +125,7 @@ class SubscriptionAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationF
           threshold = Threshold(mandatoryRegistration = false, None, None, None)
         )),
         business = Some(testBusiness.copy(businessActivities = Some(Nil))),
-        returns = Some(testReturns.copy(appliedForExemption = Some(true))),
+        vatApplication = Some(testVatApplicationDetails.copy(appliedForExemption = Some(true))),
         flatRateScheme = Some(validEmptyFlatRateScheme)
       )
 
@@ -138,7 +140,7 @@ class SubscriptionAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationF
           threshold = Threshold(mandatoryRegistration = false, None, None, None)
         )),
         business = Some(testBusiness.copy(businessActivities = Some(Nil))),
-        returns = Some(testReturns.copy(appliedForExemption = Some(true))),
+        vatApplication = Some(testVatApplicationDetails.copy(appliedForExemption = Some(true))),
         flatRateScheme = None
       )
 
@@ -151,7 +153,7 @@ class SubscriptionAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationF
       val vatScheme = testVatScheme.copy(
         eligibilitySubmissionData = Some(testEligibilitySubmissionData),
         business = Some(testBusiness),
-        returns = Some(testReturns),
+        vatApplication = Some(testVatApplicationDetails),
         flatRateScheme = Some(invalidEmptyFlatRateScheme)
       )
 
@@ -163,7 +165,7 @@ class SubscriptionAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationF
       intercept[InternalServerException](TestService.buildSubscriptionBlock(testVatScheme))
         .message mustBe "[SubscriptionBlockBuilder] Could not build subscription block " +
         "for submission because some of the data is missing: EligibilitySubmissionData found - false, " +
-        "Returns found - false, Business found - false."
+        "VatApplication found - false, Business found - false."
     }
 
     "fail if any of the repository requests return nothing" in {
@@ -174,7 +176,7 @@ class SubscriptionAuditBlockBuilderSpec extends VatRegSpec with VatRegistrationF
       intercept[InternalServerException](TestService.buildSubscriptionBlock(vatScheme))
         .message mustBe "[SubscriptionBlockBuilder] Could not build subscription block " +
         "for submission because some of the data is missing: EligibilitySubmissionData found - true, " +
-        "Returns found - false, Business found - false."
+        "VatApplication found - false, Business found - false."
     }
   }
 }

--- a/test/services/submission/AdminBlockBuilderSpec.scala
+++ b/test/services/submission/AdminBlockBuilderSpec.scala
@@ -61,13 +61,13 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
 
   "buildAdminBlock" should {
     "return an admin block json object" when {
-      "both eligibility and trading details data are in the database" in {
+      "both eligibility and vat application details data are in the database" in {
         when(mockAttachmentService.getAttachmentList(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Set[AttachmentType]()))
 
         val vatScheme = testVatScheme.copy(
           eligibilitySubmissionData = Some(testEligibilitySubmissionData),
-          tradingDetails = Some(validFullTradingDetails)
+          vatApplication = Some(testVatApplicationDetails)
         )
 
         val result = TestBuilder.buildAdminBlock(vatScheme)
@@ -75,10 +75,10 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
         result mustBe expectedJson
       }
 
-      "both NETP eligibility and trading details data are in the database" in {
+      "both NETP eligibility and vat application details data are in the database" in {
         val vatScheme = testVatScheme.copy(
           eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(partyType = NETP)),
-          tradingDetails = Some(validFullTradingDetails),
+          vatApplication = Some(testVatApplicationDetails),
           attachments = Some(Attachments(Post))
         )
 
@@ -93,7 +93,7 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
       "NETP the attachment method is Email" in {
         val vatScheme = testVatScheme.copy(
           eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(partyType = NETP)),
-          tradingDetails = Some(validFullTradingDetails),
+          vatApplication = Some(testVatApplicationDetails),
           attachments = Some(Attachments(EmailMethod))
         )
 
@@ -113,7 +113,7 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
 
         val vatScheme = testVatScheme.copy(
           eligibilitySubmissionData = None,
-          tradingDetails = Some(validFullTradingDetails),
+          vatApplication = Some(testVatApplicationDetails),
           attachments = Some(Attachments(Post))
         )
 
@@ -122,13 +122,13 @@ class AdminBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture with 
         }
       }
 
-      "the trading details data is missing from the database" in {
+      "the vat application details data is missing from the database" in {
         when(mockAttachmentService.getAttachmentList(ArgumentMatchers.eq(testRegId)))
           .thenReturn(Future.successful(Set[AttachmentType]()))
 
         val vatScheme = testVatScheme.copy(
           eligibilitySubmissionData = Some(testEligibilitySubmissionData),
-          tradingDetails = None,
+          vatApplication = None,
           attachments = Some(Attachments(Post))
         )
 

--- a/test/services/submission/AnnualAccountingBlockBuilderSpec.scala
+++ b/test/services/submission/AnnualAccountingBlockBuilderSpec.scala
@@ -43,7 +43,7 @@ class AnnualAccountingBlockBuilderSpec extends VatRegSpec with VatRegistrationFi
     "return the correct json" when {
       "the applicant wants to join AAS and all data is provided" in new Setup {
         val vatScheme = testVatScheme.copy(
-          returns = Some(validAASReturns),
+          vatApplication = Some(validAASApplicationDeatils),
           eligibilitySubmissionData = Some(testEligibilitySubmissionData)
         )
 

--- a/test/services/submission/PeriodsBlockBuilderSpec.scala
+++ b/test/services/submission/PeriodsBlockBuilderSpec.scala
@@ -19,7 +19,7 @@ package services.submission
 import fixtures.VatRegistrationFixture
 import helpers.VatRegSpec
 import mocks.MockVatSchemeRepository
-import models.api.returns._
+import models.api.vatapplication._
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.InternalServerException
 
@@ -27,24 +27,10 @@ class PeriodsBlockBuilderSpec extends VatRegSpec with MockVatSchemeRepository wi
 
   object TestBuilder extends PeriodsBlockBuilder
 
-  val emptyReturns: Returns = Returns(
-    turnoverEstimate = Some(testTurnover),
-    appliedForExemption = None,
-    zeroRatedSupplies = None,
-    reclaimVatOnMostReturns = false,
-    returnsFrequency = Quarterly,
-    staggerStart = JanuaryStagger,
-    startDate = Some(testDate),
-    annualAccountingDetails = None,
-    overseasCompliance = None,
-    northernIrelandProtocol = None,
-    hasTaxRepresentative = None
-  )
-
   "the periods block builder" should {
     "write the correct json for the monthly stagger" in {
-      val monthlyReturns = testReturns.copy(returnsFrequency = Monthly, staggerStart = MonthlyStagger)
-      val vatScheme = testVatScheme.copy(returns = Some(monthlyReturns))
+      val monthlyReturns = testVatApplicationDetails.copy(returnsFrequency = Some(Monthly), staggerStart = Some(MonthlyStagger))
+      val vatScheme = testVatScheme.copy(vatApplication = Some(monthlyReturns))
 
       val res = TestBuilder.buildPeriodsBlock(vatScheme)
 
@@ -53,8 +39,8 @@ class PeriodsBlockBuilderSpec extends VatRegSpec with MockVatSchemeRepository wi
       )
     }
     "write the correct json for stagger 1" in {
-      val stagger1Returns = testReturns.copy(staggerStart = JanuaryStagger)
-      val vatScheme = testVatScheme.copy(returns = Some(stagger1Returns))
+      val stagger1ApplicationDetails = testVatApplicationDetails.copy(staggerStart = Some(JanuaryStagger))
+      val vatScheme = testVatScheme.copy(vatApplication = Some(stagger1ApplicationDetails))
 
       val res = TestBuilder.buildPeriodsBlock(vatScheme)
 
@@ -63,8 +49,8 @@ class PeriodsBlockBuilderSpec extends VatRegSpec with MockVatSchemeRepository wi
       )
     }
     "write the correct json for stagger 2" in {
-      val stagger2Returns = testReturns.copy(staggerStart = FebruaryStagger)
-      val vatScheme = testVatScheme.copy(returns = Some(stagger2Returns))
+      val stagger2ApplicationDetails = testVatApplicationDetails.copy(staggerStart = Some(FebruaryStagger))
+      val vatScheme = testVatScheme.copy(vatApplication = Some(stagger2ApplicationDetails))
 
       val res = TestBuilder.buildPeriodsBlock(vatScheme)
 
@@ -73,8 +59,8 @@ class PeriodsBlockBuilderSpec extends VatRegSpec with MockVatSchemeRepository wi
       )
     }
     "write the correct json for stagger 3" in {
-      val stagger3Returns = testReturns.copy(staggerStart = MarchStagger)
-      val vatScheme = testVatScheme.copy(returns = Some(stagger3Returns))
+      val stagger3ApplicationDetails = testVatApplicationDetails.copy(staggerStart = Some(MarchStagger))
+      val vatScheme = testVatScheme.copy(vatApplication = Some(stagger3ApplicationDetails))
 
       val res = TestBuilder.buildPeriodsBlock(vatScheme)
 

--- a/test/services/submission/SubscriptionBlockBuilderSpec.scala
+++ b/test/services/submission/SubscriptionBlockBuilderSpec.scala
@@ -21,7 +21,7 @@ import helpers.VatRegSpec
 import mocks.MockVatSchemeRepository
 import models._
 import models.api._
-import models.api.returns._
+import models.api.vatapplication._
 import models.submission.{IdType, NETP, UtrIdType, VrnIdType}
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.http.InternalServerException
@@ -33,19 +33,6 @@ class SubscriptionBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
   object TestService extends SubscriptionBlockBuilder
 
   override lazy val testDate = LocalDate.of(2020, 2, 2)
-  override lazy val testReturns = Returns(
-    Some(testTurnover),
-    None,
-    Some(12.99),
-    reclaimVatOnMostReturns = false,
-    Quarterly,
-    JanuaryStagger,
-    Some(testDate),
-    None,
-    None,
-    None,
-    None
-  )
 
   def fullSubscriptionBlockJson(reason: String = "0016"): JsValue = Json.parse(
     s"""
@@ -191,7 +178,7 @@ class SubscriptionBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
     "build a full subscription json when all data is provided and user is mandatory on a forward look" in {
       val vatScheme = testVatScheme.copy(
         applicantDetails = Some(validApplicantDetails),
-        returns = Some(testReturns),
+        vatApplication = Some(testVatApplicationDetails),
         eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(
           threshold = Threshold(
             mandatoryRegistration = true, Some(LocalDate.of(2020, 10, 1)), None, None
@@ -210,7 +197,7 @@ class SubscriptionBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
     "build a full subscription json when all data is provided and user is mandatory on a backward look" in {
       val vatScheme = testVatScheme.copy(
         applicantDetails = Some(validApplicantDetails),
-        returns = Some(testReturns),
+        vatApplication = Some(testVatApplicationDetails),
         eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(
           threshold = Threshold(
             mandatoryRegistration = true, None, Some(LocalDate.of(2020, 10, 1)), None
@@ -234,7 +221,7 @@ class SubscriptionBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
             trn = Some(testTrn)
           )
         )),
-        returns = Some(testOverseasReturns),
+        vatApplication = Some(testOverseasVatApplicationDetails),
         eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(
           threshold = Threshold(
             mandatoryRegistration = true, None, None, None, Some(LocalDate.of(2020, 10, 1))
@@ -254,7 +241,7 @@ class SubscriptionBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
     "build a minimal subscription json when minimum data is provided and user is voluntary" in {
       val vatScheme = testVatScheme.copy(
         applicantDetails = Some(validApplicantDetails),
-        returns = Some(testReturns.copy(appliedForExemption = Some(true))),
+        vatApplication = Some(testVatApplicationDetails.copy(appliedForExemption = Some(true))),
         eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(
           threshold = Threshold(mandatoryRegistration = false, None, None, None),
           registrationReason = Voluntary
@@ -271,7 +258,7 @@ class SubscriptionBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
     "build a minimal subscription json when no Flat Rate Scheme is provided" in {
       val vatScheme = testVatScheme.copy(
         applicantDetails = Some(validApplicantDetails),
-        returns = Some(testReturns.copy(appliedForExemption = Some(true))),
+        vatApplication = Some(testVatApplicationDetails.copy(appliedForExemption = Some(true))),
         eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(
           threshold = Threshold(mandatoryRegistration = false, None, None, None),
           registrationReason = Voluntary
@@ -287,7 +274,7 @@ class SubscriptionBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
     "build a minimal subscription json with other business involvements" in {
       val vatScheme = testVatScheme.copy(
         applicantDetails = Some(validApplicantDetails),
-        returns = Some(testReturns.copy(appliedForExemption = Some(true))),
+        vatApplication = Some(testVatApplicationDetails.copy(appliedForExemption = Some(true))),
         eligibilitySubmissionData = Some(testEligibilitySubmissionData.copy(
           threshold = Threshold(mandatoryRegistration = false, None, None, None),
           registrationReason = Voluntary
@@ -331,7 +318,7 @@ class SubscriptionBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
     "fail if the Flat Rate Scheme is invalid" in {
       val vatScheme = testVatScheme.copy(
         applicantDetails = Some(validApplicantDetails),
-        returns = Some(testReturns),
+        vatApplication = Some(testVatApplicationDetails),
         eligibilitySubmissionData = Some(testEligibilitySubmissionData),
         flatRateScheme = Some(invalidEmptyFlatRateScheme),
         business = Some(testBusiness)
@@ -353,7 +340,7 @@ class SubscriptionBlockBuilderSpec extends VatRegSpec with VatRegistrationFixtur
         TestService.buildSubscriptionBlock(vatScheme)
       ).message mustBe "[SubscriptionBlockBuilder] Could not build subscription block " +
         "for submission because some of the data is missing: ApplicantDetails found - true, EligibilitySubmissionData found - true, " +
-        "Returns found - false, Business found - false."
+        "VatApplication found - false, Business found - false."
     }
   }
 }


### PR DESCRIPTION
[SAR-9901](https://jira.tools.tax.service.gov.uk/browse/SAR-9901)

**New feature**

Replace returns and trading-details models with a new data block to capture as vat-application.
_This PR still keeps backward compatibility with Returns model, which will be removed post release migration of existing journeys._

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
