### PR TITLE
SAR-10071 | Upgrade hmrc-mongo-play-28 to latest version

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -23,7 +23,7 @@ object AppDependencies {
 object CompileDependencies {
   val domainVersion = "6.2.0-play-28"
   val bootstrapVersion = "5.16.0"
-  val hmrcMongoVersion = "0.66.0"
+  val hmrcMongoVersion = "0.68.0"
   val catsVersion = "1.0.0"
 
   private val playJsonVersion = "2.9.2"


### PR DESCRIPTION
[SAR-10071](https://jira.tools.tax.service.gov.uk/browse/SAR-10071)

Upgrade hmrc-mongo-play library to latest version (0.68.0)

## Checklist

* [ ] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
