### PR TITLE
SAR-10108 | Attachments tidyup as part of FE migration to use sections

### DIFF
--- a/app/services/AttachmentsService.scala
+++ b/app/services/AttachmentsService.scala
@@ -29,8 +29,6 @@ class AttachmentsService @Inject()(val registrationRepository: VatSchemeReposito
                                    upscanMongoRepository: UpscanMongoRepository
                                   )(implicit executionContext: ExecutionContext) {
 
-  private val attachmentDetailsKey = "attachments"
-
   def getAttachmentList(regId: String): Future[Set[AttachmentType]] =
     registrationRepository.retrieveVatScheme(regId).map {
       case Some(vatScheme) => attachmentList(vatScheme)
@@ -63,12 +61,6 @@ class AttachmentsService @Inject()(val registrationRepository: VatSchemeReposito
       getTaxRepresentativeAttachment(vatScheme)
     ).flatten
   }
-
-  def getAttachmentDetails(regId: String): Future[Option[Attachments]] =
-    registrationRepository.fetchBlock[Attachments](regId, attachmentDetailsKey)
-
-  def storeAttachmentDetails(regId: String, attachmentDetails: Attachments): Future[Attachments] =
-    registrationRepository.updateBlock[Attachments](regId, attachmentDetails, attachmentDetailsKey)
 
   private def getIdentityEvidenceAttachment(vatScheme: VatScheme): Option[IdentityEvidence.type] = {
     val unverifiedPersonalDetails = vatScheme.applicantDetails.exists(data => !data.personalDetails.identifiersMatch)

--- a/app/services/EmailService.scala
+++ b/app/services/EmailService.scala
@@ -26,7 +26,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class EmailService @Inject()(emailConnector: EmailConnector,
-                             attachmentsService: AttachmentsService,
                              registrationMongoRepository: VatSchemeRepository
                             )(implicit ex: ExecutionContext) {
 
@@ -59,8 +58,7 @@ class EmailService @Inject()(emailConnector: EmailConnector,
     (for {
       optVatScheme <- registrationMongoRepository.retrieveVatScheme(regId)
       vatScheme = optVatScheme.getOrElse(throw new InternalServerException(missingDataLog("VAT scheme", regId)))
-      attachmentMethod <- attachmentsService.getAttachmentDetails(regId)
-      template = attachmentMethod.map(_.method) match {
+      template = vatScheme.attachments.map(_.method) match {
         case Some(EmailMethod) => emailTemplate
         case Some(Post) => postalTemplate
         case _ => basicTemplate

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -48,6 +48,5 @@ GET         /:regId/partners                        controllers.PartnersControll
 
 GET         /:regId/attachments                     controllers.AttachmentsController.getAttachmentList(regId: String)
 GET         /:regId/incomplete-attachments          controllers.AttachmentsController.getIncompleteAttachments(regId: String)
-PUT         /:regId/attachments                     controllers.AttachmentsController.storeAttachmentDetails(regId: String)
 
 POST        /sdes-notification-callback             controllers.SdesController.sdesCallback

--- a/it/controllers/AttachmentsControllerISpec.scala
+++ b/it/controllers/AttachmentsControllerISpec.scala
@@ -43,7 +43,7 @@ class AttachmentsControllerISpec extends IntegrationStubbing {
         )
       )
 
-      val testJson = Json.obj("attachments" -> Json.arr(Json.toJson[AttachmentType](IdentityEvidence)))
+      val testJson = Json.arr(Json.toJson[AttachmentType](IdentityEvidence))
 
       val response: WSResponse = await(client(attachmentsUrl).get())
 
@@ -55,7 +55,7 @@ class AttachmentsControllerISpec extends IntegrationStubbing {
       given.user.isAuthorised
       insertIntoDb(testFullVatScheme)
 
-      val testJson = Json.parse(s"""{"attachments": []}""")
+      val testJson = Json.parse("[]")
 
       val response: WSResponse = await(client(attachmentsUrl).get())
 
@@ -77,66 +77,6 @@ class AttachmentsControllerISpec extends IntegrationStubbing {
       val response: WSResponse = await(client(attachmentsUrl).get())
 
       response.status mustBe FORBIDDEN
-    }
-  }
-
-  "PUT /:regId/attachments" when {
-    "the request json is valid" when {
-      "mongo doesn't hold an attachment method" must {
-        "return OK with the new value" in new Setup {
-          given.user.isAuthorised
-          insertIntoDb(testSoleTraderVatScheme)
-
-          val response = await(client(attachmentsUrl).put(Json.obj(
-            "method" -> "1"
-          )))
-
-          response.status mustBe OK
-          response.json mustBe Json.obj(
-            "method" -> "1"
-          )
-        }
-        "return OK for the Email psuedo-type" in new Setup {
-          given.user.isAuthorised
-          insertIntoDb(testSoleTraderVatScheme)
-
-          val response = await(client(attachmentsUrl).put(Json.obj(
-            "method" -> "email"
-          )))
-
-          response.status mustBe OK
-          response.json mustBe Json.obj(
-            "method" -> "email"
-          )
-        }
-      }
-      "mongo holds an existing attachment method" must {
-        "return OK with the updated value" in new Setup {
-          given.user.isAuthorised
-          insertIntoDb(testSoleTraderVatScheme.copy(attachments = Some(Attachments(Post))))
-
-          val response = await(client(attachmentsUrl).put(Json.obj(
-            "method" -> "1"
-          )))
-
-          response.status mustBe OK
-          response.json mustBe Json.obj(
-            "method" -> "1"
-          )
-        }
-      }
-      "the request json is invalid" must {
-        "return BAD_REQUEST" in new Setup {
-          given.user.isAuthorised
-          insertIntoDb(testSoleTraderVatScheme.copy(attachments = Some(Attachments(Post))))
-
-          val response = await(client(attachmentsUrl).put(Json.obj(
-            "methd" -> "3"
-          )))
-
-          response.status mustBe BAD_REQUEST
-        }
-      }
     }
   }
 

--- a/test/mocks/MockAttachmentsService.scala
+++ b/test/mocks/MockAttachmentsService.scala
@@ -31,11 +31,6 @@ trait MockAttachmentsService extends MockitoSugar {
 
   val mockAttachmentService: AttachmentsService = mock[AttachmentsService]
 
-  def mockGetAttachmentDetails(regId: String)
-                              (response: Future[Option[Attachments]]): OngoingStubbing[Future[Option[Attachments]]] =
-    when(mockAttachmentService.getAttachmentDetails(ArgumentMatchers.eq(regId)))
-      .thenReturn(response)
-
   def mockGetAttachmentList(regId: String)
                            (response: Future[Set[AttachmentType]]): OngoingStubbing[Future[Set[AttachmentType]]] =
     when(mockAttachmentService.getAttachmentList(ArgumentMatchers.eq(regId)))

--- a/test/services/AttachmentsServiceSpec.scala
+++ b/test/services/AttachmentsServiceSpec.scala
@@ -121,56 +121,6 @@ class AttachmentsServiceSpec extends VatRegSpec with VatRegistrationFixture with
     }
   }
 
-  "getAttachmentDetails" when {
-    "the VatScheme has no attachmentDetails" should {
-      "return None" in {
-        mockFetchBlock[Attachments](testRegId, attachmentsKey)(Future.successful(None))
-
-        val res = await(Service.getAttachmentDetails(testRegId))
-
-        res mustBe None
-      }
-    }
-    "the VatScheme contains the Post attachment method" should {
-      "return the correct attachment details" in {
-        mockFetchBlock[Attachments](testRegId, attachmentsKey)(Future.successful(Some(Attachments(Post))))
-
-        val res = await(Service.getAttachmentDetails(testRegId))
-
-        res mustBe Some(Attachments(Post))
-      }
-    }
-    "the VatScheme contains the Attached attachment method" should {
-      "return the correct attachment details" in {
-        mockFetchBlock[Attachments](testRegId, attachmentsKey)(Future.successful(Some(Attachments(Attached))))
-
-        val res = await(Service.getAttachmentDetails(testRegId))
-
-        res mustBe Some(Attachments(Attached))
-      }
-    }
-    "the VatScheme contains the Other attachment method" should {
-      "return the correct attachment details" in {
-        mockFetchBlock[Attachments](testRegId, attachmentsKey)(Future.successful(Some(Attachments(Other))))
-
-        val res = await(Service.getAttachmentDetails(testRegId))
-
-        res mustBe Some(Attachments(Other))
-      }
-    }
-  }
-
-  "storeAttachmentDetails" must {
-    "store the given attachment method" in {
-      val testAttachmentDetails = Attachments(Post)
-      mockUpdateBlock[Attachments](testRegId, testAttachmentDetails, attachmentsKey)
-
-      val res = await(Service.storeAttachmentDetails(testRegId, testAttachmentDetails))
-
-      res mustBe testAttachmentDetails
-    }
-  }
-
   "getIncompleteAttachments" must {
     val testReference = "testReference"
 

--- a/test/services/EmailServiceSpec.scala
+++ b/test/services/EmailServiceSpec.scala
@@ -51,11 +51,7 @@ class EmailServiceSpec extends VatRegSpec with VatRegistrationFixture
     "ref" -> testAckReference
   )
 
-  object TestService extends EmailService(
-    mockEmailConnector,
-    mockAttachmentService,
-    mockVatSchemeRepository
-  )
+  object TestService extends EmailService(mockEmailConnector, mockVatSchemeRepository)
 
   "the email service" when {
     "the VAT scheme exists for the user" when {
@@ -64,7 +60,6 @@ class EmailServiceSpec extends VatRegSpec with VatRegistrationFixture
           "the email sends successfully" must {
             "send the Submission Received email to the transactor's email and use the transactor name as the salutation" in {
               mockGetVatScheme(testRegId)(Some(testEmailVatScheme))
-              mockGetAttachmentDetails(testRegId)(Future.successful(Some(Attachments(EmailMethod))))
               mockSendSubmissionReceivedEmail(testEmail, emailTemplate, testParams, force = true)(Future.successful(EmailSent))
 
               val res = await(TestService.sendRegistrationReceivedEmail(testRegId))
@@ -75,7 +70,6 @@ class EmailServiceSpec extends VatRegSpec with VatRegistrationFixture
           "the email fails to send" must {
             "return EmailFailedToSend" in {
               mockGetVatScheme(testRegId)(Some(testEmailVatScheme))
-              mockGetAttachmentDetails(testRegId)(Future.successful(Some(Attachments(EmailMethod))))
               mockSendSubmissionReceivedEmail(testEmail, emailTemplate, testParams, force = true)(Future.successful(EmailFailedToSend))
 
               val res = await(TestService.sendRegistrationReceivedEmail(testRegId))
@@ -86,7 +80,6 @@ class EmailServiceSpec extends VatRegSpec with VatRegistrationFixture
           "the connection to the email service times out" must {
             "return EmailFailedToSend" in {
               mockGetVatScheme(testRegId)(Some(testEmailVatScheme))
-              mockGetAttachmentDetails(testRegId)(Future.successful(Some(Attachments(EmailMethod))))
               mockSendSubmissionReceivedEmail(testEmail, emailTemplate, testParams, force = true)(Future.failed(new GatewayTimeoutException("")))
 
               val res = await(TestService.sendRegistrationReceivedEmail(testRegId))
@@ -100,7 +93,6 @@ class EmailServiceSpec extends VatRegSpec with VatRegistrationFixture
             "send the Submission Received email to the applicant's email and use the applicant name as the salutation" in {
               val vatScheme = testEmailVatScheme.copy(transactorDetails = None)
               mockGetVatScheme(testRegId)(Some(vatScheme))
-              mockGetAttachmentDetails(testRegId)(Future.successful(Some(Attachments(EmailMethod))))
               mockSendSubmissionReceivedEmail(testApplicantEmail, emailTemplate, testParams, force = true)(Future.successful(EmailSent))
 
               val res = await(TestService.sendRegistrationReceivedEmail(testRegId))
@@ -112,7 +104,6 @@ class EmailServiceSpec extends VatRegSpec with VatRegistrationFixture
             "return EmailFailedToSend" in {
               val vatScheme = testEmailVatScheme.copy(transactorDetails = None)
               mockGetVatScheme(testRegId)(Some(vatScheme))
-              mockGetAttachmentDetails(testRegId)(Future.successful(Some(Attachments(EmailMethod))))
               mockSendSubmissionReceivedEmail(testApplicantEmail, emailTemplate, testParams, force = true)(Future.successful(EmailFailedToSend))
 
               val res = await(TestService.sendRegistrationReceivedEmail(testRegId))
@@ -127,7 +118,6 @@ class EmailServiceSpec extends VatRegSpec with VatRegistrationFixture
           val vatScheme = testEmailVatScheme.copy(applicantDetails = None, transactorDetails = None)
 
           mockGetVatScheme(testRegId)(Some(vatScheme))
-          mockGetAttachmentDetails(testRegId)(Future.successful(Some(Attachments(EmailMethod))))
 
           val res = await(TestService.sendRegistrationReceivedEmail(testRegId))
 
@@ -138,7 +128,6 @@ class EmailServiceSpec extends VatRegSpec with VatRegistrationFixture
     "the VAT scheme doesn't exist (invalid state)" must {
       "return EmailFailedToSend" in {
         mockGetVatScheme(testRegId)(None)
-        mockGetAttachmentDetails(testRegId)(Future.successful(Some(Attachments(EmailMethod))))
 
         val res = await(TestService.sendRegistrationReceivedEmail(testRegId))
 


### PR DESCRIPTION
[SAR-10108](https://jira.tools.tax.service.gov.uk/browse/SAR-10108)

- Remove old vat scheme updates for attachments
- Remove attachment method from attachment list api
- Remove unused code for attachment details (attachment method), as that's now retrieved from registration api sections

## Checklist

* [X] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
