### PR TITLE
SAR-9827 change estimatedTotalSales to BigDecimal

### DIFF
--- a/app/models/api/FlatRateScheme.scala
+++ b/app/models/api/FlatRateScheme.scala
@@ -26,7 +26,7 @@ object FlatRateScheme {
   implicit val format: Format[FlatRateScheme] = Json.format[FlatRateScheme]
 }
 
-case class BusinessGoods(estimatedTotalSales: Long, overTurnover: Boolean)
+case class BusinessGoods(estimatedTotalSales: BigDecimal, overTurnover: Boolean)
 
 object BusinessGoods {
   implicit val format: OFormat[BusinessGoods] = Json.format[BusinessGoods]

--- a/it/itutil/ITFixtures.scala
+++ b/it/itutil/ITFixtures.scala
@@ -83,7 +83,7 @@ trait ITFixtures {
   )
 
   val frsDetails = FRSDetails(
-    businessGoods = Some(BusinessGoods(12345678L, true)),
+    businessGoods = Some(BusinessGoods(BigDecimal(12345678), true)),
     startDate = Some(testDate),
     categoryOfBusiness = Some("123"),
     percent = 15,

--- a/test/fixtures/VatRegistrationFixture.scala
+++ b/test/fixtures/VatRegistrationFixture.scala
@@ -254,7 +254,7 @@ trait VatRegistrationFixture {
 
   lazy val validFullFRSDetails: FRSDetails =
     FRSDetails(
-      businessGoods = Some(BusinessGoods(1234567891011L, overTurnover = true)),
+      businessGoods = Some(BusinessGoods(BigDecimal(1234567891), overTurnover = true)),
       startDate = Some(testDate),
       categoryOfBusiness = Some("testCategory"),
       percent = 15,
@@ -332,7 +332,7 @@ trait VatRegistrationFixture {
        |{
        |  "businessGoods" : {
        |    "overTurnover": true,
-       |    "estimatedTotalSales": 1234567891011
+       |    "estimatedTotalSales": 1234567891
        |  },
        |  "startDate": "$testDate",
        |  "categoryOfBusiness":"testCategory",
@@ -356,7 +356,7 @@ trait VatRegistrationFixture {
        |{
        |  "businessGoods" : {
        |    "overTurnover": true,
-       |    "estimatedTotalSales": 1234567891011
+       |    "estimatedTotalSales": 1234567891
        |  },
        |  "startDate": "$testDate",
        |  "categoryOfBusiness":"testCategory",

--- a/test/models/FlatRateSchemeSpec.scala
+++ b/test/models/FlatRateSchemeSpec.scala
@@ -79,7 +79,7 @@ class FlatRateSchemeSpec extends BaseSpec with JsonFormatValidation with VatRegi
         val json = Json.parse(
           s"""
              |{
-             |  "estimatedTotalSales": 1234567891011
+             |  "estimatedTotalSales": 1234567891
              |}
          """.stripMargin)
         val result = Json.fromJson[BusinessGoods](json)


### PR DESCRIPTION
SAR-9827 change estimatedTotalSales to BigDecimal
This is a corresponding change for [VRS-FE] SAR-10340

**New feature**

## Checklist

* [x] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
