### PR TITLE
SAR-10639 | Return the decrypted value for sections that are conditionally decrypted

### DIFF
--- a/app/controllers/registrations/RegistrationSectionController.scala
+++ b/app/controllers/registrations/RegistrationSectionController.scala
@@ -51,10 +51,8 @@ class RegistrationSectionController @Inject()(val authConnector: AuthConnector,
       registrationService.getSection[JsValue](internalId, regId, section).flatMap {
         case Some(sectionData) =>
           sectionValidationService.validate(internalId, regId, section, cipherService.conditionallyDecrypt(section, sectionData)).map {
-            case Right(ValidSection(_)) =>
-              Ok(sectionData)
-            case Left(response@InvalidSection(_)) =>
-              InternalServerError(response.asString)
+            case Right(ValidSection(value)) => Ok(value)
+            case Left(response@InvalidSection(_)) => InternalServerError(response.asString)
           }
         case _ =>
           Future.successful(NotFound)

--- a/it/controllers/registrations/RegistrationSectionControllerISpec.scala
+++ b/it/controllers/registrations/RegistrationSectionControllerISpec.scala
@@ -1,8 +1,10 @@
 
 package controllers.registrations
 
+import auth.CryptoSCRS
 import itutil.IntegrationStubbing
-import models.registration.TransactorSectionId
+import models.api.{BankAccount, BankAccountMongoFormat}
+import models.registration.{BankAccountSectionId, TransactorSectionId}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 
@@ -24,7 +26,20 @@ class RegistrationSectionControllerISpec extends IntegrationStubbing {
         res.status mustBe OK
         res.json mustBe Json.toJson(testTransactorDetails)
       }
+
+      "return OK with decrypted json for a decryptable section" in new SetupHelper {
+        val testBankAccount: BankAccount = BankAccount(isProvided = true, Some(testBankDetails), None, None)
+
+        given.user.isAuthorised
+        insertIntoDb(testVatScheme.copy(bankAccount = Some(testBankAccount)))
+
+        val res = await(client(url(BankAccountSectionId.key)).get())
+
+        res.status mustBe OK
+        res.json mustBe Json.toJson(testBankAccount)
+      }
     }
+
     "the section doesn't exist in the registration" must {
       "return NOT FOUND" in new SetupHelper {
         given.user.isAuthorised


### PR DESCRIPTION
[SAR-10639](https://jira.tools.tax.service.gov.uk/browse/SAR-10639)

**Bug fix**

Though the value read from db was conditionally decrypted, the decrypted value was being ignored and instead the db read value was returned. Fix to return decrypted value in getSection. 

## Checklist

* [X] I've included appropriate tests with any code I've added
* [X] I've executed the acceptance test pack locally to ensure there are no regressions
* [X] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date 
