### PR TITLE
feat: add FailedVerification reason 

### DIFF
--- a/app/models/api/NoUKBankAccount.scala
+++ b/app/models/api/NoUKBankAccount.scala
@@ -25,6 +25,7 @@ case object OverseasAccount extends NoUKBankAccount
 case object NameChange extends NoUKBankAccount
 case object AccountNotInBusinessName extends NoUKBankAccount
 case object DontWantToProvide extends NoUKBankAccount
+case object FailedVerification extends NoUKBankAccount
 
 object NoUKBankAccount {
 
@@ -38,6 +39,8 @@ object NoUKBankAccount {
   val accountNotInBusinessNameId: String = "6"
   val dontWantToProvide: String          = "DontWantToProvide"
   val dontWantToProvideId: String        = "7"
+  val failedVerification: String         = "FailedVerification"
+  val failedVerificationId: String       = "8"
 
   implicit val reads: Reads[NoUKBankAccount] = Reads[NoUKBankAccount] {
     case JsString(`beingSetup`)               => JsSuccess(BeingSetup)
@@ -45,6 +48,7 @@ object NoUKBankAccount {
     case JsString(`nameChange`)               => JsSuccess(NameChange)
     case JsString(`accountNotInBusinessName`) => JsSuccess(AccountNotInBusinessName)
     case JsString(`dontWantToProvide`)        => JsSuccess(DontWantToProvide)
+    case JsString(`failedVerification`)       => JsSuccess(FailedVerification)
     case _                                    => JsError("Could not parse reason for no UK bank account")
   }
 
@@ -54,6 +58,7 @@ object NoUKBankAccount {
     case NameChange               => JsString(nameChange)
     case AccountNotInBusinessName => JsString(accountNotInBusinessName)
     case DontWantToProvide        => JsString(dontWantToProvide)
+    case FailedVerification       => JsString(failedVerification)
   }
 
   implicit val format: Format[NoUKBankAccount] = Format(reads, writes)
@@ -64,6 +69,7 @@ object NoUKBankAccount {
     case NameChange               => nameChangeId
     case AccountNotInBusinessName => accountNotInBusinessNameId
     case DontWantToProvide        => dontWantToProvideId
+    case FailedVerification       => failedVerificationId
   }
 
 }

--- a/test/fixtures/VatRegistrationFixture.scala
+++ b/test/fixtures/VatRegistrationFixture.scala
@@ -255,6 +255,7 @@ trait VatRegistrationFixture {
 
   lazy val testBankAccount: BankAccount = BankAccount(isProvided = true, details = Some(testBankDetails), None)
   lazy val testBankAccountNotProvided: BankAccount = BankAccount(isProvided = false, details = None, reason = Some(BeingSetup))
+  lazy val testfailedVerficationBankAccount: BankAccount = BankAccount(isProvided = false, details = None, reason = Some(FailedVerification))
 
   protected lazy val validAASDetails: AASDetails = AASDetails(
     paymentMethod = Some(StandingOrder),

--- a/test/services/submission/BankDetailsBlockBuilderSpec.scala
+++ b/test/services/submission/BankDetailsBlockBuilderSpec.scala
@@ -71,6 +71,12 @@ class BankDetailsBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture
     )
   )
 
+  val bankDetailsFailedVerificationBlockJson: JsObject = Json.obj(
+    "UK" -> Json.obj(
+      "reasonBankAccNotProvided" -> NoUKBankAccount.reasonId(FailedVerification)
+    )
+  )
+
   "buildBankDetailsBlock" should {
     "return the correct json" when {
       "the applicant has a bank account" in new Setup {
@@ -131,6 +137,16 @@ class BankDetailsBlockBuilderSpec extends VatRegSpec with VatRegistrationFixture
 
         val result: Option[JsObject] = service.buildBankDetailsBlock(vatScheme)
         result mustBe Some(bankDetailsNotProvidedBlockJson)
+      }
+
+      "the applicant failed verification on their bank details" in new Setup {
+        val vatScheme = testVatScheme.copy(
+          bankAccount = Some(testfailedVerficationBankAccount),
+          eligibilitySubmissionData = Some(testEligibilitySubmissionData)
+        )
+
+        val result: Option[JsObject] = service.buildBankDetailsBlock(vatScheme)
+        result mustBe Some(bankDetailsFailedVerificationBlockJson)
       }
 
       "the bank account is missing and user is a NETP" in new Setup {


### PR DESCRIPTION
When a user is locked out due to failed verification the reason to be saved as part of the journey 
Add failedVerificationReason to be used when user is locked out
New feature
